### PR TITLE
Add page helper bridge for WhatsApp audio retrieval

### DIFF
--- a/whatsapp-ai-extension/content.js
+++ b/whatsapp-ai-extension/content.js
@@ -8,6 +8,9 @@ class WhatsAppAIAssistant {
       model: 'gpt-4o',
       responseStyle: 'Responda de forma natural e contextual, mantendo o tom da conversa'
     };
+    this.pageBridgeRequests = new Map();
+    this.boundHandlePageBridgeMessage = this.handlePageBridgeMessage.bind(this);
+    this._pageBridgeListenerAttached = false;
     console.log('[WhatsApp AI] Construtor iniciado');
     this.init();
   }
@@ -15,9 +18,12 @@ class WhatsAppAIAssistant {
   async init() {
     console.log('[WhatsApp AI] Inicializando...');
     await this.loadSettings();
+    this.setupPageStoreBridge().catch(error => {
+      console.warn('[WhatsApp AI] Falha ao iniciar bridge do Store', error);
+    });
     this.createFloatingButton();
     this.observeConversationChanges();
-    
+
     // Expor instância globalmente para debug
     window.whatsappAI = this;
     console.log('[WhatsApp AI] Inicialização completa');
@@ -33,6 +39,100 @@ class WhatsAppAIAssistant {
       };
     } catch (error) {
       console.log('Erro ao carregar configurações:', error);
+    }
+  }
+
+  setupPageStoreBridge() {
+    if (!this._pageBridgeListenerAttached) {
+      window.addEventListener('message', this.boundHandlePageBridgeMessage);
+      this._pageBridgeListenerAttached = true;
+    }
+
+    if (!this._pageStoreBridgePromise) {
+      this._pageStoreBridgePromise = new Promise((resolve, reject) => {
+        try {
+          const script = document.createElement('script');
+          script.src = chrome.runtime.getURL('page-store.js');
+          script.async = false;
+          script.onload = () => {
+            script.remove();
+            resolve();
+          };
+          script.onerror = (error) => {
+            script.remove();
+            reject(new Error('Falha ao carregar helper do Store do WhatsApp'));
+          };
+          (document.head || document.documentElement).appendChild(script);
+        } catch (error) {
+          reject(error);
+        }
+      }).catch(error => {
+        console.warn('[WhatsApp AI] Erro ao injetar bridge do Store', error);
+        if (this._pageBridgeListenerAttached) {
+          window.removeEventListener('message', this.boundHandlePageBridgeMessage);
+          this._pageBridgeListenerAttached = false;
+        }
+        this._pageStoreBridgePromise = null;
+        throw error;
+      });
+    }
+
+    return this._pageStoreBridgePromise;
+  }
+
+  async requestPageStoreAction(action, payload = {}, timeoutMs = 8000) {
+    await this.setupPageStoreBridge();
+
+    return new Promise((resolve, reject) => {
+      const requestId = `wa_store_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+
+      const timeout = setTimeout(() => {
+        this.pageBridgeRequests.delete(requestId);
+        reject(new Error('Timeout ao comunicar com helper do Store'));
+      }, timeoutMs);
+
+      this.pageBridgeRequests.set(requestId, { resolve, reject, timeout });
+
+      window.postMessage(
+        {
+          type: 'WA_STORE_REQUEST',
+          action,
+          requestId,
+          ...payload
+        },
+        '*'
+      );
+    });
+  }
+
+  handlePageBridgeMessage(event) {
+    if (event.source !== window || !event.data) {
+      return;
+    }
+
+    const data = event.data;
+
+    if (data.type === 'WA_STORE_READY') {
+      console.log('[WhatsApp AI] Bridge do Store pronta');
+      return;
+    }
+
+    if (data.type !== 'WA_STORE_RESPONSE' || !data.requestId) {
+      return;
+    }
+
+    const pending = this.pageBridgeRequests.get(data.requestId);
+    if (!pending) {
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pageBridgeRequests.delete(data.requestId);
+
+    if (data.success) {
+      pending.resolve({ blob: data.blob, metadata: data.metadata });
+    } else {
+      pending.reject(new Error(data.error || 'Falha desconhecida no helper do Store'));
     }
   }
 
@@ -431,79 +531,29 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
   }
 
   async ensureWhatsAppStore() {
-    if (this._whatsAppStorePromise) {
-      return this._whatsAppStorePromise;
+    try {
+      await this.requestPageStoreAction('ENSURE_STORE', {}, 5000);
+      return true;
+    } catch (error) {
+      console.warn('[WhatsApp AI] Não foi possível inicializar helper do Store', error);
+      return false;
     }
-
-    if (window.Store?.Msg) {
-      this._whatsAppStorePromise = Promise.resolve(window.Store);
-      return this._whatsAppStorePromise;
-    }
-
-    const promise = new Promise((resolve, reject) => {
-      const chunk = window.webpackChunkwhatsapp_web_client;
-      if (!chunk || typeof chunk.push !== 'function') {
-        reject(new Error('webpackChunkwhatsapp_web_client não encontrado'));
-        return;
-      }
-
-      const moduleId = `__wa_store_${Date.now()}`;
-
-      const timeout = setTimeout(() => {
-        reject(new Error('Timeout ao carregar Store do WhatsApp'));
-      }, 5000);
-
-      try {
-        chunk.push([
-          [moduleId],
-          {},
-          (__webpack_require__) => {
-            try {
-              const moduleMap = __webpack_require__.m || {};
-              for (const key of Object.keys(moduleMap)) {
-                try {
-                  const module = __webpack_require__(key);
-                  const candidate = module?.default?.Msg ? module.default : module;
-                  if (candidate?.Msg) {
-                    window.Store = candidate;
-                    clearTimeout(timeout);
-                    resolve(candidate);
-                    return;
-                  }
-                } catch (innerError) {
-                  console.warn('[WhatsApp AI] Erro ao avaliar módulo WhatsApp', innerError);
-                }
-              }
-              clearTimeout(timeout);
-              reject(new Error('Store.Msg não encontrado nos módulos do WhatsApp'));
-            } catch (error) {
-              clearTimeout(timeout);
-              reject(error);
-            }
-          }
-        ]);
-      } catch (error) {
-        clearTimeout(timeout);
-        reject(error);
-      }
-    });
-
-    this._whatsAppStorePromise = promise.catch(error => {
-      this._whatsAppStorePromise = null;
-      throw error;
-    });
-
-    return this._whatsAppStorePromise;
   }
 
   async getWhatsAppMessageById(messageId) {
+    if (!messageId) {
+      return null;
+    }
+
+    const isReady = await this.ensureWhatsAppStore();
+    if (!isReady) {
+      return null;
+    }
+
     try {
-      const store = await this.ensureWhatsAppStore();
-      if (!store?.Msg) return null;
-      const message = store.Msg.get?.(messageId) || store.Msg.find?.(msg => msg?.id?._serialized === messageId || msg?.id === messageId);
-      return message || null;
+      return await this.requestPageStoreAction('GET_AUDIO_BLOB', { messageId }, 12000);
     } catch (error) {
-      console.warn('[WhatsApp AI] Não foi possível obter Store.Msg', error);
+      console.warn('[WhatsApp AI] Não foi possível obter mídia via helper do Store', error);
       return null;
     }
   }
@@ -514,59 +564,29 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
     try {
       const messageId = this.getMessageIdFromElement(messageElement);
       if (messageId) {
-        console.log(`[WhatsApp AI] Tentando obter mídia via Store para mensagem ${messageId}`);
+        console.log(`[WhatsApp AI] Solicitando mídia via helper para mensagem ${messageId}`);
         try {
-          const storeMessage = await this.getWhatsAppMessageById(messageId);
-          if (storeMessage?.mediaData) {
-            if (!storeMessage.mediaData.mediaBlob && !storeMessage.mediaData._mediaBlob && !storeMessage.mediaData.blob) {
-              console.log('[WhatsApp AI] Blob não carregado, tentando download interno...');
-              try {
-                if (typeof storeMessage.downloadMedia === 'function') {
-                  await storeMessage.downloadMedia();
-                } else {
-                  throw new Error('Método downloadMedia indisponível');
-                }
-              } catch (downloadError) {
-                console.warn('[WhatsApp AI] Falha ao baixar mídia internamente', downloadError);
-                this.showNotification('⚠️ Não foi possível baixar o áudio internamente. Tentando métodos alternativos...', 'warning');
-              }
-            }
+          const helperResponse = await this.getWhatsAppMessageById(messageId);
+          const helperBlob = helperResponse?.blob;
+          if (helperBlob instanceof Blob) {
+            console.log('[WhatsApp AI] Áudio obtido via helper do Store');
+            const metadata = helperResponse?.metadata || {};
+            const mimeType = helperBlob.type || metadata.mimeType || 'audio/ogg';
+            const fileName = metadata.fileName || 'whatsapp-audio.ogg';
 
-            const internalBlob =
-              storeMessage.mediaData.mediaBlob ||
-              storeMessage.mediaData._mediaBlob ||
-              storeMessage.mediaData.blob ||
-              storeMessage.mediaData.file ||
-              storeMessage.mediaData?.mediaBlobUrl;
+            const audioFile = helperBlob instanceof File
+              ? helperBlob
+              : new File([helperBlob], fileName, { type: mimeType });
 
-            let blobForProcessing = null;
-            if (internalBlob instanceof Blob) {
-              blobForProcessing = internalBlob;
-            } else if (internalBlob?.blob instanceof Blob) {
-              blobForProcessing = internalBlob.blob;
-            } else if (typeof internalBlob === 'string' && internalBlob.startsWith('blob:')) {
-              console.log('[WhatsApp AI] URL de blob interno encontrada');
-              return await this.processAudioBlob(internalBlob);
-            }
-
-            if (blobForProcessing) {
-              console.log('[WhatsApp AI] Áudio obtido via Store');
-              const audioFile = blobForProcessing instanceof File
-                ? blobForProcessing
-                : new File([blobForProcessing], 'whatsapp-audio.ogg', {
-                    type: blobForProcessing.type || storeMessage.mediaData?.type || 'audio/ogg'
-                  });
-
-              const objectUrl = URL.createObjectURL(audioFile);
-              try {
-                return await this.processAudioBlob(objectUrl);
-              } finally {
-                setTimeout(() => URL.revokeObjectURL(objectUrl), 5000);
-              }
+            const objectUrl = URL.createObjectURL(audioFile);
+            try {
+              return await this.processAudioBlob(objectUrl);
+            } finally {
+              setTimeout(() => URL.revokeObjectURL(objectUrl), 5000);
             }
           }
         } catch (storeError) {
-          console.warn('[WhatsApp AI] Falha ao obter mídia via Store', storeError);
+          console.warn('[WhatsApp AI] Falha ao obter mídia via helper', storeError);
           this.showNotification('⚠️ Não foi possível acessar o áudio internamente. Tentando métodos alternativos...', 'warning');
         }
       }

--- a/whatsapp-ai-extension/manifest.json
+++ b/whatsapp-ai-extension/manifest.json
@@ -33,7 +33,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["icons/*"],
+      "resources": ["icons/*", "page-store.js"],
       "matches": ["https://web.whatsapp.com/*"]
     }
   ]

--- a/whatsapp-ai-extension/page-store.js
+++ b/whatsapp-ai-extension/page-store.js
@@ -1,0 +1,251 @@
+(function () {
+  const REQUEST_TYPE = 'WA_STORE_REQUEST';
+  const RESPONSE_TYPE = 'WA_STORE_RESPONSE';
+  const READY_TYPE = 'WA_STORE_READY';
+
+  const logPrefix = '[WhatsApp AI][PageStore]';
+
+  function log(...args) {
+    try {
+      console.log(logPrefix, ...args);
+    } catch (e) {
+      // Ignore logging issues
+    }
+  }
+
+  let storePromise = null;
+
+  function findStoreInModules(__webpack_require__) {
+    const moduleMap = (__webpack_require__ && __webpack_require__.m) || {};
+    for (const key of Object.keys(moduleMap)) {
+      try {
+        const module = __webpack_require__(key);
+        const candidate = module && module.default && module.default.Msg ? module.default : module;
+        if (candidate && candidate.Msg) {
+          return candidate;
+        }
+      } catch (error) {
+        log('Erro ao avaliar módulo WhatsApp', error);
+      }
+    }
+    return null;
+  }
+
+  function ensureStoreInternal() {
+    if (window.Store && window.Store.Msg) {
+      return Promise.resolve(window.Store);
+    }
+
+    if (storePromise) {
+      return storePromise;
+    }
+
+    storePromise = new Promise((resolve, reject) => {
+      const chunk = window.webpackChunkwhatsapp_web_client;
+      if (!chunk || typeof chunk.push !== 'function') {
+        reject(new Error('webpackChunkwhatsapp_web_client não encontrado'));
+        return;
+      }
+
+      const moduleId = `__wa_store_${Date.now()}`;
+      let resolved = false;
+
+      const timeout = setTimeout(() => {
+        if (!resolved) {
+          reject(new Error('Timeout ao localizar Store do WhatsApp'));
+        }
+      }, 5000);
+
+      try {
+        chunk.push([
+          [moduleId],
+          {},
+          (__webpack_require__) => {
+            try {
+              const store = findStoreInModules(__webpack_require__);
+              if (store && store.Msg) {
+                resolved = true;
+                clearTimeout(timeout);
+                window.Store = store;
+                resolve(store);
+                return;
+              }
+              throw new Error('Store.Msg não encontrado nos módulos do WhatsApp');
+            } catch (error) {
+              clearTimeout(timeout);
+              reject(error);
+            }
+          }
+        ]);
+      } catch (error) {
+        clearTimeout(timeout);
+        reject(error);
+      }
+    }).catch(error => {
+      storePromise = null;
+      throw error;
+    });
+
+    return storePromise;
+  }
+
+  async function ensureStore() {
+    const store = await ensureStoreInternal();
+    if (store && store.Msg) {
+      return store;
+    }
+    throw new Error('Store.Msg indisponível');
+  }
+
+  async function ensureMessageMediaBlob(message) {
+    if (!message || !message.mediaData) {
+      throw new Error('Mensagem não possui dados de mídia');
+    }
+
+    const mediaData = message.mediaData;
+
+    if (
+      !mediaData.mediaBlob &&
+      !mediaData._mediaBlob &&
+      !mediaData.blob &&
+      !mediaData.file &&
+      !mediaData.mediaBlobUrl
+    ) {
+      if (typeof message.downloadMedia === 'function') {
+        try {
+          await message.downloadMedia();
+        } catch (error) {
+          log('Falha ao baixar mídia internamente', error);
+        }
+      }
+    }
+
+    const candidate =
+      mediaData.mediaBlob ||
+      mediaData._mediaBlob ||
+      mediaData.blob ||
+      mediaData.file ||
+      mediaData.mediaBlobUrl;
+
+    if (candidate instanceof Blob) {
+      return { blob: candidate, mimeType: candidate.type || mediaData.type || mediaData.mimetype };
+    }
+
+    if (candidate && candidate.blob instanceof Blob) {
+      const blob = candidate.blob;
+      return { blob, mimeType: blob.type || mediaData.type || mediaData.mimetype };
+    }
+
+    if (typeof candidate === 'string') {
+      try {
+        const response = await fetch(candidate);
+        if (!response.ok) {
+          throw new Error(`Falha ao carregar blob da URL: ${response.status}`);
+        }
+        const blob = await response.blob();
+        return { blob, mimeType: blob.type || mediaData.type || mediaData.mimetype };
+      } catch (error) {
+        throw new Error(`Não foi possível obter blob a partir da URL: ${error.message}`);
+      }
+    }
+
+    throw new Error('Blob de áudio indisponível para a mensagem');
+  }
+
+  async function getAudioBlobByMessageId(messageId) {
+    if (!messageId) {
+      throw new Error('messageId inválido');
+    }
+
+    const store = await ensureStore();
+    const message =
+      (store.Msg && typeof store.Msg.get === 'function' && store.Msg.get(messageId)) ||
+      (store.Msg && typeof store.Msg.find === 'function' &&
+        store.Msg.find((msg) => {
+          const id = msg && msg.id;
+          return (
+            id === messageId ||
+            (id && (id._serialized === messageId || id.id === messageId))
+          );
+        }));
+
+    if (!message) {
+      throw new Error('Mensagem não encontrada no Store');
+    }
+
+    const result = await ensureMessageMediaBlob(message);
+    const fileName =
+      (message.mediaData && (message.mediaData.filename || message.mediaData.fileName)) ||
+      'whatsapp-audio.ogg';
+
+    return {
+      blob: result.blob,
+      metadata: {
+        mimeType: result.mimeType || 'audio/ogg',
+        fileName
+      }
+    };
+  }
+
+  function respond(requestId, success, payload) {
+    window.postMessage(
+      {
+        type: RESPONSE_TYPE,
+        requestId,
+        success,
+        ...payload
+      },
+      '*'
+    );
+  }
+
+  window.addEventListener('message', (event) => {
+    if (event.source !== window) {
+      return;
+    }
+
+    const data = event.data;
+    if (!data || data.type !== REQUEST_TYPE) {
+      return;
+    }
+
+    const { requestId, action, messageId } = data;
+
+    if (!requestId) {
+      return;
+    }
+
+    if (action === 'ENSURE_STORE') {
+      ensureStore()
+        .then(() => {
+          respond(requestId, true, {});
+        })
+        .catch((error) => {
+          respond(requestId, false, { error: error.message });
+        });
+      return;
+    }
+
+    if (action === 'GET_AUDIO_BLOB') {
+      getAudioBlobByMessageId(messageId)
+        .then((result) => {
+          respond(requestId, true, {
+            blob: result.blob,
+            metadata: result.metadata
+          });
+        })
+        .catch((error) => {
+          respond(requestId, false, { error: error.message || 'Erro desconhecido' });
+        });
+      return;
+    }
+  });
+
+  ensureStore()
+    .then(() => {
+      window.postMessage({ type: READY_TYPE }, '*');
+    })
+    .catch((error) => {
+      log('Falha inicial ao garantir Store', error);
+    });
+})();


### PR DESCRIPTION
## Summary
- add a page-context helper that locates WhatsApp's Store.Msg and returns requested audio blobs through postMessage
- inject the helper from the content script, manage request/response plumbing, and fetch blobs via the bridge during transcription
- expose the helper script via web_accessible_resources so it can be injected into the page

## Testing
- not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68d188e6f1c4832fa6cb709f39d07a79