### PR TITLE
Relax audio source filtering and reuse last known URL

### DIFF
--- a/whatsapp-ai-extension/content.js
+++ b/whatsapp-ai-extension/content.js
@@ -8,6 +8,7 @@ class WhatsAppAIAssistant {
       model: 'gpt-4o',
       responseStyle: 'Responda de forma natural e contextual, mantendo o tom da conversa'
     };
+    this.lastKnownAudioSrc = null;
     this.pageBridgeRequests = new Map();
     this.boundHandlePageBridgeMessage = this.handlePageBridgeMessage.bind(this);
     this._pageBridgeListenerAttached = false;
@@ -643,15 +644,18 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
       let audioElement = messageElement.querySelector('audio');
       console.log(`[WhatsApp AI] Áudio na mensagem: ${audioElement ? 'ENCONTRADO' : 'NÃO ENCONTRADO'}`);
 
-      if (audioElement && audioElement.src && audioElement.src.startsWith('blob:')) {
-        console.log(`[WhatsApp AI] Usando áudio da mensagem: ${audioElement.src.substring(0, 50)}...`);
-        return await this.processAudioBlob(audioElement.src);
+      const directAudioSrc = this.resolveAudioSource(audioElement);
+      if (directAudioSrc) {
+        console.log(`[WhatsApp AI] Usando áudio da mensagem: ${directAudioSrc.substring(0, 50)}...`);
+        this.lastKnownAudioSrc = directAudioSrc;
+        return await this.processAudioBlob(directAudioSrc);
       }
-      
+
       // Método 2: Buscar na estrutura do WhatsApp sem reproduzir
       const audioData = this.findAudioInMessage(messageElement);
       if (audioData) {
         console.log(`[WhatsApp AI] Áudio encontrado via estrutura: ${audioData.src.substring(0, 50)}...`);
+        this.lastKnownAudioSrc = audioData.src;
         return await this.processAudioBlob(audioData.src);
       }
       
@@ -659,6 +663,7 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
       const recentAudio = this.findRecentAudioBlob();
       if (recentAudio) {
         console.log(`[WhatsApp AI] Usando áudio recente: ${recentAudio.substring(0, 50)}...`);
+        this.lastKnownAudioSrc = recentAudio;
         return await this.processAudioBlob(recentAudio);
       }
       
@@ -666,6 +671,7 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
       const extractedAudio = await this.extractAudioWithoutPlay(messageElement);
       if (extractedAudio) {
         console.log('[WhatsApp AI] Áudio extraído sem reprodução');
+        this.lastKnownAudioSrc = extractedAudio;
         return await this.processAudioBlob(extractedAudio);
       }
       
@@ -679,56 +685,186 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
 
   findAudioInMessage(messageElement) {
     console.log('[WhatsApp AI] Procurando áudio na estrutura da mensagem...');
-    
+
     // Buscar em diferentes estruturas possíveis
     const possibleContainers = [
       messageElement,
+      messageElement.parentElement,
+      messageElement.closest('[data-id]'),
       messageElement.querySelector('[data-testid*="audio"]'),
       messageElement.querySelector('[class*="audio"]'),
       messageElement.querySelector('[class*="ptt"]')
     ].filter(Boolean);
-    
+
     for (const container of possibleContainers) {
-      const audio = container.querySelector('audio');
-      if (audio && audio.src && audio.src.startsWith('blob:')) {
+      const directAudio = container.querySelector('audio');
+      const directSrc = this.resolveAudioSource(directAudio);
+      if (directAudio && directSrc) {
         console.log('[WhatsApp AI] Áudio encontrado em container');
-        return { src: audio.src, element: audio };
+        return { src: directSrc, element: directAudio };
+      }
+
+      // Procurar também por <source> fora do <audio>
+      const looseSource = container.querySelector('source[src], source[data-src]');
+      const looseSrc = this.resolveElementUrl(looseSource);
+      if (looseSource && looseSrc) {
+        console.log('[WhatsApp AI] Áudio encontrado via elemento <source> avulso');
+        return { src: looseSrc, element: looseSource };
+      }
+
+      // Procurar âncoras ou botões com href/data-ref apontando para mídia
+      const linkWithMedia = container.querySelector('a[href], button[data-ref], div[data-ref]');
+      const linkSrc = this.resolveElementUrl(linkWithMedia);
+      if (linkWithMedia && linkSrc) {
+        console.log('[WhatsApp AI] Áudio encontrado via atributo de mídia');
+        return { src: linkSrc, element: linkWithMedia };
       }
     }
-    
+
     return null;
   }
 
   findRecentAudioBlob() {
     console.log('[WhatsApp AI] Buscando blobs de áudio recentes...');
-    
-    const allAudios = Array.from(document.querySelectorAll('audio[src^="blob:"]'));
-    console.log(`[WhatsApp AI] Total de áudios blob encontrados: ${allAudios.length}`);
-    
-    if (allAudios.length === 0) return null;
-    
+
+    const audioElements = document.querySelectorAll('audio, source[src], source[data-src]');
+    const allAudios = Array.from(audioElements).map(element => ({
+      element,
+      src: element.tagName.toLowerCase() === 'audio'
+        ? this.resolveAudioSource(element)
+        : this.resolveElementUrl(element)
+    })).filter(item => !!item.src);
+    console.log(`[WhatsApp AI] Total de áudios encontrados: ${allAudios.length}`);
+
+    if (allAudios.length === 0) {
+      if (this.lastKnownAudioSrc) {
+        console.log('[WhatsApp AI] Reutilizando último áudio conhecido global');
+        return this.lastKnownAudioSrc;
+      }
+
+      return null;
+    }
+
     // Pegar o mais recente (último na lista)
     const recentAudio = allAudios[allAudios.length - 1];
+    this.lastKnownAudioSrc = recentAudio.src;
     return recentAudio.src;
   }
 
   async extractAudioWithoutPlay(messageElement) {
     console.log('[WhatsApp AI] Tentando extrair áudio sem reprodução...');
-    
+
     // Procurar por elementos que podem conter referência ao áudio
-    const audioButtons = messageElement.querySelectorAll('[data-testid*="audio"], [data-icon*="audio"], button[aria-label*="áudio"]');
-    
+    const audioButtons = messageElement.querySelectorAll('[data-testid*="audio"], [data-icon*="audio"], button[aria-label*="áudio"], button[aria-label*="voice"], button[aria-label*="voz"]');
+
     for (const button of audioButtons) {
       // Verificar se há um elemento audio próximo
       const nearbyAudio = button.parentElement?.querySelector('audio') ||
                          button.closest('[class*="message"]')?.querySelector('audio');
-      
-      if (nearbyAudio && nearbyAudio.src && nearbyAudio.src.startsWith('blob:')) {
+
+      const nearbySrc = this.resolveAudioSource(nearbyAudio);
+      if (nearbyAudio && nearbySrc) {
         console.log('[WhatsApp AI] Áudio encontrado próximo ao botão');
-        return nearbyAudio.src;
+        return nearbySrc;
+      }
+
+      const sourceElement = button.closest('[class*="message"]')?.querySelector('source[src], source[data-src]');
+      const sourceUrl = this.resolveElementUrl(sourceElement);
+      if (sourceElement && sourceUrl) {
+        console.log('[WhatsApp AI] Áudio encontrado via elemento <source> próximo ao botão');
+        return sourceUrl;
+      }
+
+      const referencedUrl = this.resolveElementUrl(button);
+      if (referencedUrl) {
+        console.log('[WhatsApp AI] Áudio encontrado em atributo do botão');
+        return referencedUrl;
       }
     }
-    
+
+    if (this.lastKnownAudioSrc) {
+      console.log('[WhatsApp AI] Reutilizando último áudio conhecido');
+      return this.lastKnownAudioSrc;
+    }
+
+    return null;
+  }
+
+  resolveElementUrl(element) {
+    if (!element) {
+      return null;
+    }
+
+    const candidateValues = [];
+
+    if (typeof element.currentSrc === 'string' && element.currentSrc.trim()) {
+      candidateValues.push(element.currentSrc.trim());
+    }
+
+    if (typeof element.src === 'string' && element.src.trim()) {
+      candidateValues.push(element.src.trim());
+    }
+
+    const attributeNames = ['src', 'href', 'data-src', 'data-href', 'data-ref', 'data-url', 'data-media-url', 'data-mediakey'];
+    for (const attr of attributeNames) {
+      const attrValue = element.getAttribute?.(attr);
+      if (attrValue && attrValue.trim()) {
+        candidateValues.push(attrValue.trim());
+      }
+    }
+
+    const datasetKeys = ['ref', 'src', 'href', 'url', 'mediaUrl', 'mediaurl', 'mediaRef'];
+    for (const key of datasetKeys) {
+      const value = element.dataset?.[key];
+      if (value && value.trim()) {
+        candidateValues.push(value.trim());
+      }
+    }
+
+    const parentLink = element.closest?.('a[href], button[href]');
+    if (parentLink?.href) {
+      candidateValues.push(parentLink.href.trim());
+    }
+
+    for (const rawValue of candidateValues) {
+      const value = rawValue.trim();
+      if (!value) {
+        continue;
+      }
+
+      try {
+        const absolute = new URL(value, window.location.href).toString();
+        if (absolute) {
+          return absolute;
+        }
+      } catch (error) {
+        console.warn('[WhatsApp AI] Não foi possível resolver URL relativa de mídia', error);
+      }
+
+      return value;
+    }
+
+    return null;
+  }
+
+  resolveAudioSource(audioElement) {
+    if (!audioElement) {
+      return null;
+    }
+
+    const directUrl = this.resolveElementUrl(audioElement);
+    if (directUrl) {
+      return directUrl;
+    }
+
+    const sourceElements = audioElement.querySelectorAll('source, a[href]');
+    for (const sourceElement of sourceElements) {
+      const resolved = this.resolveElementUrl(sourceElement);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
     return null;
   }
 
@@ -743,7 +879,9 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
         const blobUrl = source;
         console.log(`[WhatsApp AI] URL: ${blobUrl.substring(0, 50)}...`);
         console.log('[WhatsApp AI] Fazendo fetch do blob...');
-        const response = await fetch(blobUrl);
+        const response = await fetch(blobUrl, {
+          credentials: 'include'
+        });
 
         if (!response.ok) {
           throw new Error(`Erro HTTP ${response.status}: ${response.statusText}`);


### PR DESCRIPTION
## Summary
- remember each discovered audio URL so it can be reused on subsequent transcription attempts
- fall back to the globally cached audio URL when no playable elements are present in the DOM
- accept any non-empty media reference by resolving relative URLs and returning raw values when normalization fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d19695ba30832f9d4e896c633b7986