### PR TITLE
Handle helper download results when locating audio blobs

### DIFF
--- a/tests/page_store_get_last_audio_blob.test.js
+++ b/tests/page_store_get_last_audio_blob.test.js
@@ -1,0 +1,147 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { Blob } = require('buffer');
+
+async function run() {
+  const messageHandlers = new Set();
+  const responseHandlers = new Set();
+  const readyEvents = [];
+
+  let downloadCalls = 0;
+
+  const audioBlob = new Blob(['audio-mock'], { type: 'audio/ogg' });
+
+  const message = {
+    type: 'ptt',
+    mediaType: 'audio',
+    id: { _serialized: 'message-1' },
+    mediaData: {
+      mimetype: 'audio/ogg'
+    },
+    async downloadMedia() {
+      downloadCalls += 1;
+      return { blob: audioBlob };
+    }
+  };
+
+  const store = {
+    Msg: {
+      get(messageId) {
+        if (messageId === 'message-1') {
+          return message;
+        }
+        return null;
+      }
+    },
+    Chat: {
+      getActive() {
+        return {
+          msgs: {
+            getModels() {
+              return [message];
+            }
+          }
+        };
+      }
+    }
+  };
+
+  const window = {
+    Store: store,
+    postMessage(payload) {
+      if (!payload || typeof payload !== 'object') {
+        return;
+      }
+
+      if (payload.type === 'WA_STORE_RESPONSE') {
+        responseHandlers.forEach((handler) => handler(payload));
+      } else if (payload.type === 'WA_STORE_READY') {
+        readyEvents.push(payload);
+      }
+    },
+    addEventListener(type, handler) {
+      if (type === 'message' && typeof handler === 'function') {
+        messageHandlers.add(handler);
+      }
+    },
+    removeEventListener(type, handler) {
+      if (type === 'message') {
+        messageHandlers.delete(handler);
+      }
+    }
+  };
+
+  global.window = window;
+  global.Blob = global.Blob || Blob;
+  global.fetch = global.fetch || (async () => {
+    throw new Error('fetch não disponível no ambiente de teste');
+  });
+  global.console = console;
+
+  const scriptContent = fs.readFileSync(
+    path.join(__dirname, '..', 'whatsapp-ai-extension', 'page-store.js'),
+    'utf8'
+  );
+
+  vm.runInThisContext(scriptContent, { filename: 'page-store.js' });
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.strictEqual(readyEvents.length, 1, 'helper deve sinalizar READY após carregamento');
+
+  function dispatchMessage(data) {
+    messageHandlers.forEach((handler) => {
+      handler({ source: window, data });
+    });
+  }
+
+  function waitForResponse(requestId) {
+    return new Promise((resolve) => {
+      const handler = (payload) => {
+        if (payload.requestId === requestId) {
+          responseHandlers.delete(handler);
+          resolve(payload);
+        }
+      };
+      responseHandlers.add(handler);
+    });
+  }
+
+  async function request(action, extra = {}) {
+    const requestId = `test_${Math.random().toString(16).slice(2)}`;
+    const pending = waitForResponse(requestId);
+    dispatchMessage({
+      type: 'WA_STORE_REQUEST',
+      action,
+      requestId,
+      ...extra
+    });
+    return pending;
+  }
+
+  const lastAudioResponse = await request('GET_LAST_AUDIO_BLOB');
+  assert.strictEqual(lastAudioResponse.success, true, 'GET_LAST_AUDIO_BLOB deve responder com sucesso');
+  assert.ok(lastAudioResponse.blob, 'blob deve ser retornado');
+  const bufferFromLastAudio = Buffer.from(await lastAudioResponse.blob.arrayBuffer());
+  assert.strictEqual(bufferFromLastAudio.toString(), 'audio-mock');
+  assert.strictEqual(
+    downloadCalls,
+    1,
+    'downloadMedia deve ser chamado uma única vez para buscar o blob ausente'
+  );
+
+  const audioByIdResponse = await request('GET_AUDIO_BLOB', { messageId: 'message-1' });
+  assert.strictEqual(audioByIdResponse.success, true, 'GET_AUDIO_BLOB deve responder com sucesso');
+  assert.ok(audioByIdResponse.blob, 'blob deve ser retornado para GET_AUDIO_BLOB');
+  const bufferFromAudioById = Buffer.from(await audioByIdResponse.blob.arrayBuffer());
+  assert.strictEqual(bufferFromAudioById.toString(), 'audio-mock');
+
+  console.log('✔ Testes do helper do Store passaram com sucesso');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/whatsapp-ai-extension/page-store.js
+++ b/whatsapp-ai-extension/page-store.js
@@ -168,20 +168,20 @@
     }
 
     const mediaData = message.mediaData;
+    let downloadResult = null;
 
-    if (
-      !mediaData.mediaBlob &&
-      !mediaData._mediaBlob &&
-      !mediaData.blob &&
-      !mediaData.file &&
-      !mediaData.mediaBlobUrl
-    ) {
-      if (typeof message.downloadMedia === 'function') {
-        try {
-          await message.downloadMedia();
-        } catch (error) {
-          log('Falha ao baixar mídia internamente', error);
-        }
+    const hasInlineBlob =
+      mediaData.mediaBlob ||
+      mediaData._mediaBlob ||
+      mediaData.blob ||
+      mediaData.file ||
+      mediaData.mediaBlobUrl;
+
+    if (!hasInlineBlob && typeof message.downloadMedia === 'function') {
+      try {
+        downloadResult = await message.downloadMedia();
+      } catch (error) {
+        log('Falha ao baixar mídia internamente', error);
       }
     }
 
@@ -190,7 +190,13 @@
       mediaData._mediaBlob ||
       mediaData.blob ||
       mediaData.file ||
-      mediaData.mediaBlobUrl;
+      mediaData.mediaBlobUrl ||
+      (downloadResult &&
+        (downloadResult.mediaBlob ||
+          downloadResult._mediaBlob ||
+          downloadResult.blob ||
+          downloadResult.file ||
+          downloadResult.mediaBlobUrl));
 
     if (candidate instanceof Blob) {
       return { blob: candidate, mimeType: candidate.type || mediaData.type || mediaData.mimetype };
@@ -212,6 +218,13 @@
       } catch (error) {
         throw new Error(`Não foi possível obter blob a partir da URL: ${error.message}`);
       }
+    }
+
+    if (downloadResult && downloadResult.buffer instanceof ArrayBuffer) {
+      const blob = new Blob([downloadResult.buffer], {
+        type: mediaData.type || mediaData.mimetype || 'audio/ogg'
+      });
+      return { blob, mimeType: blob.type };
     }
 
     throw new Error('Blob de áudio indisponível para a mensagem');
@@ -250,6 +263,160 @@
         fileName
       }
     };
+  }
+
+  function collectionToArray(candidate) {
+    if (!candidate) {
+      return [];
+    }
+
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+
+    if (typeof candidate.toArray === 'function') {
+      try {
+        const array = candidate.toArray();
+        if (Array.isArray(array)) {
+          return array;
+        }
+      } catch (error) {
+        log('Falha ao converter coleção para array via toArray', error);
+      }
+    }
+
+    if (typeof candidate.values === 'function') {
+      try {
+        return Array.from(candidate.values());
+      } catch (error) {
+        log('Falha ao converter coleção para array via values()', error);
+      }
+    }
+
+    if (typeof candidate.forEach === 'function') {
+      const array = [];
+      try {
+        candidate.forEach((value) => {
+          array.push(value);
+        });
+      } catch (error) {
+        log('Falha ao converter coleção para array via forEach()', error);
+      }
+
+      if (array.length) {
+        return array;
+      }
+    }
+
+    if (typeof candidate === 'object') {
+      try {
+        const values = Object.values(candidate).filter((value) =>
+          value && typeof value === 'object'
+        );
+        if (values.length) {
+          return values;
+        }
+      } catch (error) {
+        log('Falha ao converter objeto para array', error);
+      }
+    }
+
+    return [];
+  }
+
+  function resolveMessageModels(messagesCollection) {
+    if (!messagesCollection) {
+      return [];
+    }
+
+    const extractionStrategies = [
+      () =>
+        typeof messagesCollection.getModelsArray === 'function'
+          ? messagesCollection.getModelsArray()
+          : null,
+      () =>
+        typeof messagesCollection.getModels === 'function'
+          ? messagesCollection.getModels()
+          : null,
+      () =>
+        typeof messagesCollection.all === 'function'
+          ? messagesCollection.all()
+          : null,
+      () => messagesCollection.models,
+      () => messagesCollection._models
+    ];
+
+    for (const getCandidate of extractionStrategies) {
+      let candidate = null;
+      try {
+        candidate = getCandidate();
+      } catch (error) {
+        log('Falha ao extrair mensagens da conversa ativa', error);
+      }
+
+      const asArray = collectionToArray(candidate);
+      if (asArray.length) {
+        return asArray;
+      }
+    }
+
+    return collectionToArray(messagesCollection);
+  }
+
+  async function getLastAudioBlobFromActiveChat() {
+    const store = await ensureStore();
+
+    const activeChat =
+      store.Chat && typeof store.Chat.getActive === 'function'
+        ? store.Chat.getActive()
+        : null;
+
+    const messagesCollection = activeChat && activeChat.msgs;
+    const messageModels = resolveMessageModels(messagesCollection);
+
+    if (!Array.isArray(messageModels) || messageModels.length === 0) {
+      throw new Error('Nenhuma mensagem encontrada na conversa ativa');
+    }
+
+    for (let index = messageModels.length - 1; index >= 0; index -= 1) {
+      const message = messageModels[index];
+
+      if (!message || !message.mediaData) {
+        continue;
+      }
+
+      const messageType = message.type || message.__x_type;
+      const messageMediaType =
+        message.mediaType || message.__x_mediaType || message.mediaData.type || message.mediaData.mimetype;
+
+      if (messageType !== 'ptt' && messageMediaType !== 'audio') {
+        continue;
+      }
+
+      try {
+        const result = await ensureMessageMediaBlob(message);
+        const mediaData = message.mediaData || {};
+        const fileName = mediaData.filename || mediaData.fileName || 'whatsapp-audio.ogg';
+        const id = message.id;
+        const serializedId =
+          typeof id === 'string'
+            ? id
+            : id && (id._serialized || id.id || (typeof id.toString === 'function' ? id.toString() : null));
+
+        return {
+          blob: result.blob,
+          metadata: {
+            mimeType: result.mimeType || mediaData.mimetype || 'audio/ogg',
+            fileName,
+            messageId: serializedId || null
+          }
+        };
+      } catch (error) {
+        log('Falha ao garantir blob da última mensagem de áudio', error);
+      }
+    }
+
+    throw new Error('Nenhuma mensagem de voz encontrada na conversa ativa');
   }
 
   function respond(requestId, success, payload) {
@@ -293,6 +460,20 @@
 
     if (action === 'GET_AUDIO_BLOB') {
       getAudioBlobByMessageId(messageId)
+        .then((result) => {
+          respond(requestId, true, {
+            blob: result.blob,
+            metadata: result.metadata
+          });
+        })
+        .catch((error) => {
+          respond(requestId, false, { error: error.message || 'Erro desconhecido' });
+        });
+      return;
+    }
+
+    if (action === 'GET_LAST_AUDIO_BLOB') {
+      getLastAudioBlobFromActiveChat()
         .then((result) => {
           respond(requestId, true, {
             blob: result.blob,


### PR DESCRIPTION
## Summary
- capture downloadMedia results when a message has no inline audio blob available and reuse any blob-like values it returns
- convert array buffers returned by the download helper into blobs before giving them back to the content script
- add a node-based regression test that exercises the helper bridge for GET_LAST_AUDIO_BLOB and GET_AUDIO_BLOB scenarios

## Testing
- node tests/page_store_get_last_audio_blob.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1d5a58714832f8d32fad4ed6fc959