### PR TITLE
Improve WhatsApp store helper audio blob decoding

### DIFF
--- a/tests/page_store_get_last_audio_blob.test.js
+++ b/tests/page_store_get_last_audio_blob.test.js
@@ -1,0 +1,193 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { Blob } = require('buffer');
+
+async function run() {
+  const messageHandlers = new Set();
+  const responseHandlers = new Set();
+  const readyEvents = [];
+
+  let downloadCallsInline = 0;
+  let downloadCallsDataUrl = 0;
+
+  const inlineBlob = new Blob(['audio-inline'], { type: 'audio/ogg' });
+  const dataUrlPayload = Buffer.from('audio-from-data').toString('base64');
+  const fullDataUrl = `data:audio/ogg; codecs=opus;base64,${dataUrlPayload}`;
+
+  const inlineMessage = {
+    type: 'ptt',
+    mediaType: 'audio',
+    id: { _serialized: 'message-inline' },
+    mediaData: {
+      mimetype: 'audio/ogg',
+      mediaBlob: inlineBlob
+    },
+    async downloadMedia() {
+      downloadCallsInline += 1;
+      return { blob: inlineBlob };
+    }
+  };
+
+  const dataUrlMessage = {
+    type: 'ptt',
+    mediaType: 'audio',
+    id: { _serialized: 'message-data-url' },
+    mediaData: {
+      mimetype: 'audio/ogg'
+    },
+    async downloadMedia() {
+      downloadCallsDataUrl += 1;
+      return {
+        data: fullDataUrl,
+        mimeType: 'audio/ogg'
+      };
+    }
+  };
+
+  const textMessage = {
+    type: 'chat',
+    mediaType: 'text',
+    id: { _serialized: 'message-text' },
+    mediaData: null
+  };
+
+  const store = {
+    Msg: {
+      get(messageId) {
+        if (messageId === 'message-inline') {
+          return inlineMessage;
+        }
+        if (messageId === 'message-data-url') {
+          return dataUrlMessage;
+        }
+        return null;
+      }
+    },
+    Chat: {
+      getActive() {
+        return {
+          msgs: {
+            getModels() {
+              return [textMessage, inlineMessage, dataUrlMessage];
+            }
+          }
+        };
+      }
+    }
+  };
+
+  const window = {
+    Store: store,
+    postMessage(payload) {
+      if (!payload || typeof payload !== 'object') {
+        return;
+      }
+
+      if (payload.type === 'WA_STORE_RESPONSE') {
+        responseHandlers.forEach((handler) => handler(payload));
+      } else if (payload.type === 'WA_STORE_READY') {
+        readyEvents.push(payload);
+      }
+    },
+    addEventListener(type, handler) {
+      if (type === 'message' && typeof handler === 'function') {
+        messageHandlers.add(handler);
+      }
+    },
+    removeEventListener(type, handler) {
+      if (type === 'message') {
+        messageHandlers.delete(handler);
+      }
+    }
+  };
+
+  global.window = window;
+  global.Blob = global.Blob || Blob;
+  global.fetch = global.fetch || (async () => {
+    throw new Error('fetch não disponível no ambiente de teste');
+  });
+  global.console = console;
+
+  const scriptContent = fs.readFileSync(
+    path.join(__dirname, '..', 'whatsapp-ai-extension', 'page-store.js'),
+    'utf8'
+  );
+
+  vm.runInThisContext(scriptContent, { filename: 'page-store.js' });
+
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.strictEqual(readyEvents.length, 1, 'helper deve sinalizar READY após carregamento');
+
+  function dispatchMessage(data) {
+    messageHandlers.forEach((handler) => {
+      handler({ source: window, data });
+    });
+  }
+
+  function waitForResponse(requestId) {
+    return new Promise((resolve) => {
+      const handler = (payload) => {
+        if (payload.requestId === requestId) {
+          responseHandlers.delete(handler);
+          resolve(payload);
+        }
+      };
+      responseHandlers.add(handler);
+    });
+  }
+
+  async function request(action, extra = {}) {
+    const requestId = `test_${Math.random().toString(16).slice(2)}`;
+    const pending = waitForResponse(requestId);
+    dispatchMessage({
+      type: 'WA_STORE_REQUEST',
+      action,
+      requestId,
+      ...extra
+    });
+    return pending;
+  }
+
+  const lastAudioResponse = await request('GET_LAST_AUDIO_BLOB');
+  assert.strictEqual(lastAudioResponse.success, true, 'GET_LAST_AUDIO_BLOB deve responder com sucesso');
+  assert.ok(lastAudioResponse.blob, 'blob deve ser retornado');
+  const bufferFromLastAudio = Buffer.from(await lastAudioResponse.blob.arrayBuffer());
+  assert.strictEqual(bufferFromLastAudio.toString(), 'audio-from-data');
+  assert.strictEqual(
+    downloadCallsDataUrl,
+    1,
+    'downloadMedia deve ser chamado uma única vez para converter data URL em blob'
+  );
+
+  const audioByIdInlineResponse = await request('GET_AUDIO_BLOB', { messageId: 'message-inline' });
+  assert.strictEqual(audioByIdInlineResponse.success, true, 'GET_AUDIO_BLOB deve responder com sucesso');
+  assert.ok(audioByIdInlineResponse.blob, 'blob inline deve ser retornado');
+  const bufferFromInline = Buffer.from(await audioByIdInlineResponse.blob.arrayBuffer());
+  assert.strictEqual(bufferFromInline.toString(), 'audio-inline');
+  assert.strictEqual(downloadCallsInline, 0, 'downloadMedia não deve ser chamado quando blob inline está presente');
+
+  const audioByIdDataUrlResponse = await request('GET_AUDIO_BLOB', { messageId: 'message-data-url' });
+  assert.strictEqual(
+    audioByIdDataUrlResponse.success,
+    true,
+    'GET_AUDIO_BLOB deve responder com sucesso para mensagem com data URL'
+  );
+  assert.ok(audioByIdDataUrlResponse.blob, 'blob deve ser retornado a partir do data URL');
+  const bufferFromAudioById = Buffer.from(await audioByIdDataUrlResponse.blob.arrayBuffer());
+  assert.strictEqual(bufferFromAudioById.toString(), 'audio-from-data');
+  assert.strictEqual(
+    downloadCallsDataUrl,
+    2,
+    'downloadMedia deve ser chamado novamente quando blob precisa ser recuperado por id'
+  );
+
+  console.log('✔ Testes do helper do Store passaram com sucesso');
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/whatsapp-ai-extension/page-store.js
+++ b/whatsapp-ai-extension/page-store.js
@@ -162,55 +162,250 @@
     throw new Error('Store.Msg indisponível');
   }
 
+  function isBlobLike(candidate) {
+    if (!candidate) {
+      return false;
+    }
+
+    if (typeof Blob !== 'undefined' && candidate instanceof Blob) {
+      return true;
+    }
+
+    const tag = Object.prototype.toString.call(candidate);
+    return tag === '[object Blob]' || tag === '[object File]';
+  }
+
+  function unwrapBlob(candidate) {
+    if (!candidate) {
+      return null;
+    }
+
+    if (isBlobLike(candidate)) {
+      return candidate;
+    }
+
+    if (candidate.blob && isBlobLike(candidate.blob)) {
+      return candidate.blob;
+    }
+
+    if (candidate._blob && isBlobLike(candidate._blob)) {
+      return candidate._blob;
+    }
+
+    if (candidate.data && isBlobLike(candidate.data)) {
+      return candidate.data;
+    }
+
+    return null;
+  }
+
+  function decodeBase64ToUint8Array(base64) {
+    if (typeof base64 !== 'string' || !base64) {
+      return null;
+    }
+
+    try {
+      if (typeof atob === 'function') {
+        const normalized = base64.replace(/\s+/g, '');
+        const binary = atob(normalized);
+        const bytes = new Uint8Array(binary.length);
+        for (let index = 0; index < binary.length; index += 1) {
+          bytes[index] = binary.charCodeAt(index);
+        }
+        return bytes;
+      }
+
+      if (typeof Buffer !== 'undefined') {
+        const buffer = Buffer.from(base64, 'base64');
+        return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.length);
+      }
+    } catch (error) {
+      log('Falha ao decodificar base64 para Uint8Array', error);
+    }
+
+    return null;
+  }
+
+  function blobFromDataString(dataString, fallbackMimeType) {
+    if (typeof dataString !== 'string' || !dataString) {
+      return null;
+    }
+
+    let mimeType = fallbackMimeType || 'application/octet-stream';
+    let payload = dataString;
+    let isBase64 = true;
+
+    if (dataString.startsWith('data:')) {
+      const commaIndex = dataString.indexOf(',');
+      if (commaIndex === -1) {
+        return null;
+      }
+
+      const metadata = dataString.substring(5, commaIndex);
+      const segments = metadata
+        .split(';')
+        .map((segment) => segment.trim())
+        .filter(Boolean);
+      if (segments.length > 0) {
+        mimeType = segments[0];
+      }
+
+      isBase64 = segments.includes('base64');
+      payload = dataString.substring(commaIndex + 1);
+
+      if (!isBase64) {
+        try {
+          const decoded = decodeURIComponent(payload);
+          return new Blob([decoded], { type: mimeType });
+        } catch (error) {
+          log('Falha ao decodificar data URI não-base64', error);
+          return null;
+        }
+      }
+    }
+
+    const bytes = decodeBase64ToUint8Array(payload);
+    if (!bytes) {
+      return null;
+    }
+
+    return new Blob([bytes.buffer], { type: mimeType });
+  }
+
+  function coerceStringToBlob(candidate, fallbackMimeType) {
+    if (typeof candidate !== 'string' || !candidate) {
+      return null;
+    }
+
+    if (candidate.startsWith('data:')) {
+      return blobFromDataString(candidate, fallbackMimeType);
+    }
+
+    return null;
+  }
+
+  async function fetchBlobFromUrl(url, fallbackMimeType) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const blob = await response.blob();
+      if (!blob.type && fallbackMimeType) {
+        return new Blob([await blob.arrayBuffer()], { type: fallbackMimeType });
+      }
+      return blob;
+    } catch (error) {
+      throw new Error(`Não foi possível obter blob a partir da URL: ${error.message}`);
+    }
+  }
+
+  function resolveMediaUrls(mediaData, downloadResult) {
+    const urls = [];
+
+    if (mediaData) {
+      const mediaUrls = [
+        mediaData.mediaBlobUrl,
+        mediaData.mediaUrl,
+        mediaData.url,
+        mediaData.clientUrl,
+        mediaData.directPath ? `https://mmg.whatsapp.net${mediaData.directPath}` : null,
+        mediaData.streamableUrl,
+        mediaData.renderableUrl
+      ];
+
+      mediaUrls.forEach((value) => {
+        if (typeof value === 'string' && value) {
+          urls.push(value);
+        }
+      });
+    }
+
+    if (downloadResult) {
+      const downloadUrls = [
+        downloadResult.mediaBlobUrl,
+        downloadResult.url,
+        downloadResult.directPath ? `https://mmg.whatsapp.net${downloadResult.directPath}` : null,
+        downloadResult.clientUrl
+      ];
+
+      downloadUrls.forEach((value) => {
+        if (typeof value === 'string' && value) {
+          urls.push(value);
+        }
+      });
+    }
+
+    return urls.filter(Boolean);
+  }
+
   async function ensureMessageMediaBlob(message) {
     if (!message || !message.mediaData) {
       throw new Error('Mensagem não possui dados de mídia');
     }
 
     const mediaData = message.mediaData;
+    let downloadResult = null;
 
-    if (
-      !mediaData.mediaBlob &&
-      !mediaData._mediaBlob &&
-      !mediaData.blob &&
-      !mediaData.file &&
-      !mediaData.mediaBlobUrl
-    ) {
-      if (typeof message.downloadMedia === 'function') {
-        try {
-          await message.downloadMedia();
-        } catch (error) {
-          log('Falha ao baixar mídia internamente', error);
-        }
+    const inlineBlob =
+      unwrapBlob(mediaData.mediaBlob) ||
+      unwrapBlob(mediaData._mediaBlob) ||
+      unwrapBlob(mediaData.blob) ||
+      unwrapBlob(mediaData.file);
+
+    if (!inlineBlob && typeof message.downloadMedia === 'function') {
+      try {
+        downloadResult = await message.downloadMedia();
+      } catch (error) {
+        log('Falha ao baixar mídia internamente', error);
       }
     }
 
-    const candidate =
-      mediaData.mediaBlob ||
-      mediaData._mediaBlob ||
-      mediaData.blob ||
-      mediaData.file ||
-      mediaData.mediaBlobUrl;
+    const preferredMimeType =
+      mediaData.type ||
+      mediaData.mimetype ||
+      mediaData.mimeType ||
+      (downloadResult && (downloadResult.mimeType || downloadResult.mimetype)) ||
+      'audio/ogg';
 
-    if (candidate instanceof Blob) {
-      return { blob: candidate, mimeType: candidate.type || mediaData.type || mediaData.mimetype };
+    const downloadBlob =
+      unwrapBlob(downloadResult && downloadResult.mediaBlob) ||
+      unwrapBlob(downloadResult && downloadResult._mediaBlob) ||
+      unwrapBlob(downloadResult && downloadResult.blob) ||
+      unwrapBlob(downloadResult && downloadResult.file) ||
+      unwrapBlob(downloadResult && downloadResult.data);
+
+    const dataUrlBlob =
+      (typeof mediaData.data === 'string' && blobFromDataString(mediaData.data, preferredMimeType)) ||
+      (downloadResult && typeof downloadResult.data === 'string'
+        ? blobFromDataString(downloadResult.data, preferredMimeType)
+        : null);
+
+    const bufferBlob =
+      downloadResult && downloadResult.buffer instanceof ArrayBuffer
+        ? new Blob([downloadResult.buffer], { type: preferredMimeType })
+        : null;
+
+    const candidateBlob = inlineBlob || downloadBlob || dataUrlBlob || bufferBlob;
+
+    if (candidateBlob) {
+      return { blob: candidateBlob, mimeType: candidateBlob.type || preferredMimeType };
     }
 
-    if (candidate && candidate.blob instanceof Blob) {
-      const blob = candidate.blob;
-      return { blob, mimeType: blob.type || mediaData.type || mediaData.mimetype };
-    }
+    const urls = resolveMediaUrls(mediaData, downloadResult);
+    for (const url of urls) {
+      const directBlob = coerceStringToBlob(url, preferredMimeType);
+      if (directBlob) {
+        return { blob: directBlob, mimeType: directBlob.type || preferredMimeType };
+      }
 
-    if (typeof candidate === 'string') {
       try {
-        const response = await fetch(candidate);
-        if (!response.ok) {
-          throw new Error(`Falha ao carregar blob da URL: ${response.status}`);
+        const fetchedBlob = await fetchBlobFromUrl(url, preferredMimeType);
+        if (fetchedBlob) {
+          return { blob: fetchedBlob, mimeType: fetchedBlob.type || preferredMimeType };
         }
-        const blob = await response.blob();
-        return { blob, mimeType: blob.type || mediaData.type || mediaData.mimetype };
       } catch (error) {
-        throw new Error(`Não foi possível obter blob a partir da URL: ${error.message}`);
+        log('Falha ao obter blob a partir de URL conhecida da mídia', error);
       }
     }
 
@@ -250,6 +445,160 @@
         fileName
       }
     };
+  }
+
+  function collectionToArray(candidate) {
+    if (!candidate) {
+      return [];
+    }
+
+    if (Array.isArray(candidate)) {
+      return candidate;
+    }
+
+    if (typeof candidate.toArray === 'function') {
+      try {
+        const array = candidate.toArray();
+        if (Array.isArray(array)) {
+          return array;
+        }
+      } catch (error) {
+        log('Falha ao converter coleção para array via toArray', error);
+      }
+    }
+
+    if (typeof candidate.values === 'function') {
+      try {
+        return Array.from(candidate.values());
+      } catch (error) {
+        log('Falha ao converter coleção para array via values()', error);
+      }
+    }
+
+    if (typeof candidate.forEach === 'function') {
+      const array = [];
+      try {
+        candidate.forEach((value) => {
+          array.push(value);
+        });
+      } catch (error) {
+        log('Falha ao converter coleção para array via forEach()', error);
+      }
+
+      if (array.length) {
+        return array;
+      }
+    }
+
+    if (typeof candidate === 'object') {
+      try {
+        const values = Object.values(candidate).filter((value) =>
+          value && typeof value === 'object'
+        );
+        if (values.length) {
+          return values;
+        }
+      } catch (error) {
+        log('Falha ao converter objeto para array', error);
+      }
+    }
+
+    return [];
+  }
+
+  function resolveMessageModels(messagesCollection) {
+    if (!messagesCollection) {
+      return [];
+    }
+
+    const extractionStrategies = [
+      () =>
+        typeof messagesCollection.getModelsArray === 'function'
+          ? messagesCollection.getModelsArray()
+          : null,
+      () =>
+        typeof messagesCollection.getModels === 'function'
+          ? messagesCollection.getModels()
+          : null,
+      () =>
+        typeof messagesCollection.all === 'function'
+          ? messagesCollection.all()
+          : null,
+      () => messagesCollection.models,
+      () => messagesCollection._models
+    ];
+
+    for (const getCandidate of extractionStrategies) {
+      let candidate = null;
+      try {
+        candidate = getCandidate();
+      } catch (error) {
+        log('Falha ao extrair mensagens da conversa ativa', error);
+      }
+
+      const asArray = collectionToArray(candidate);
+      if (asArray.length) {
+        return asArray;
+      }
+    }
+
+    return collectionToArray(messagesCollection);
+  }
+
+  async function getLastAudioBlobFromActiveChat() {
+    const store = await ensureStore();
+
+    const activeChat =
+      store.Chat && typeof store.Chat.getActive === 'function'
+        ? store.Chat.getActive()
+        : null;
+
+    const messagesCollection = activeChat && activeChat.msgs;
+    const messageModels = resolveMessageModels(messagesCollection);
+
+    if (!Array.isArray(messageModels) || messageModels.length === 0) {
+      throw new Error('Nenhuma mensagem encontrada na conversa ativa');
+    }
+
+    for (let index = messageModels.length - 1; index >= 0; index -= 1) {
+      const message = messageModels[index];
+
+      if (!message || !message.mediaData) {
+        continue;
+      }
+
+      const messageType = message.type || message.__x_type;
+      const messageMediaType =
+        message.mediaType || message.__x_mediaType || message.mediaData.type || message.mediaData.mimetype;
+
+      if (messageType !== 'ptt' && messageMediaType !== 'audio') {
+        continue;
+      }
+
+      try {
+        const result = await ensureMessageMediaBlob(message);
+        const mediaData = message.mediaData || {};
+        const fileName = mediaData.filename || mediaData.fileName || 'whatsapp-audio.ogg';
+        const id = message.id;
+        const serializedId =
+          typeof id === 'string'
+            ? id
+            : id && (id._serialized || id.id || (typeof id.toString === 'function' ? id.toString() : null));
+
+        return {
+          blob: result.blob,
+          metadata: {
+            mimeType: result.mimeType || mediaData.mimetype || 'audio/ogg',
+            fileName,
+            messageId: serializedId || null
+          }
+        };
+      } catch (error) {
+        log('Falha ao garantir blob da última mensagem de áudio', error);
+      }
+    }
+
+    throw new Error('Nenhuma mensagem de voz encontrada na conversa ativa');
   }
 
   function respond(requestId, success, payload) {
@@ -293,6 +642,20 @@
 
     if (action === 'GET_AUDIO_BLOB') {
       getAudioBlobByMessageId(messageId)
+        .then((result) => {
+          respond(requestId, true, {
+            blob: result.blob,
+            metadata: result.metadata
+          });
+        })
+        .catch((error) => {
+          respond(requestId, false, { error: error.message || 'Erro desconhecido' });
+        });
+      return;
+    }
+
+    if (action === 'GET_LAST_AUDIO_BLOB') {
+      getLastAudioBlobFromActiveChat()
         .then((result) => {
           respond(requestId, true, {
             blob: result.blob,


### PR DESCRIPTION
## Summary
- broaden the store helper to unwrap nested blobs, decode data URL/base64 downloads, and fall back to fetching known media URLs when necessary
- ensure the last-audio lookup returns normalized blobs regardless of whether media is inline or downloaded on demand
- expand the regression test suite to cover inline blobs and data URL downloads so helper responses stay reliable

## Testing
- node tests/page_store_get_last_audio_blob.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1d5a58714832f8d32fad4ed6fc959