### PR TITLE
Handle DOM audio fallback errors and extend tests

### DIFF
--- a/whatsapp-ai-extension/content.js
+++ b/whatsapp-ai-extension/content.js
@@ -939,10 +939,15 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
 
       if (!audioBlob) {
         console.log('[WhatsApp AI] Buscando último áudio disponível no DOM');
-        const lastAudio = await this.getLastVoiceBlob();
-        audioBlob = lastAudio.blob;
-        audioElement = lastAudio.audioElement;
-        this.lastKnownAudioSrc = audioElement?.currentSrc || audioElement?.src || this.lastKnownAudioSrc;
+        try {
+          const lastAudio = await this.getLastVoiceBlob();
+          audioBlob = lastAudio.blob;
+          audioElement = lastAudio.audioElement;
+          this.lastKnownAudioSrc =
+            audioElement?.currentSrc || audioElement?.src || this.lastKnownAudioSrc;
+        } catch (error) {
+          console.warn('[WhatsApp AI] Falha ao obter último áudio do DOM', error);
+        }
       }
 
       if (!audioBlob) {


### PR DESCRIPTION
## Summary
- wrap transcribeAudio's DOM fallback in try/catch so Store fallback still executes when getLastVoiceBlob fails
- log DOM fallback errors without stopping execution and preserve lastKnownAudioSrc logic
- add regression test ensuring Store fallback succeeds when getLastVoiceBlob throws after a readiness timeout

## Testing
- node tests/transcribe_audio_store_fallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d1ffefedb8832faae80531d5a3a8fc