### PR TITLE
Handle DOM audio retrieval failures before store fallback

### DIFF
--- a/tests/transcribe_audio_store_fallback.test.js
+++ b/tests/transcribe_audio_store_fallback.test.js
@@ -290,7 +290,7 @@ async function run() {
         });
         throw new Error('Falha simulada ao obter áudio do DOM');
       },
-      lastKnownAudioSrc: null,
+      lastKnownAudioSrc: 'previous-known-src',
       transcribeBlobWithWhisper: async (blob, mimeType) => {
         const buffer = Buffer.from(await blob.arrayBuffer());
         assert.strictEqual(buffer.toString(), 'audio-from-store');
@@ -310,6 +310,11 @@ async function run() {
       storeRequestCount,
       1,
       'Fallback final deve recorrer ao Store após readiness ser sinalizado'
+    );
+    assert.strictEqual(
+      failingDomContext.lastKnownAudioSrc,
+      'previous-known-src',
+      'lastKnownAudioSrc deve permanecer inalterado quando DOM falha'
     );
 
     storeRequestCount = 0;

--- a/whatsapp-ai-extension/content.js
+++ b/whatsapp-ai-extension/content.js
@@ -939,20 +939,18 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
 
       if (!audioBlob) {
         console.log('[WhatsApp AI] Buscando último áudio disponível no DOM');
-        let lastAudio = null;
         try {
-          lastAudio = await this.getLastVoiceBlob();
+          const lastAudio = await this.getLastVoiceBlob();
+          if (lastAudio && lastAudio.blob) {
+            audioBlob = lastAudio.blob;
+            if (lastAudio.audioElement) {
+              audioElement = lastAudio.audioElement;
+              this.lastKnownAudioSrc =
+                audioElement.currentSrc || audioElement.src || this.lastKnownAudioSrc;
+            }
+          }
         } catch (error) {
           console.warn('[WhatsApp AI] Falha ao obter último áudio do DOM', error);
-        }
-
-        if (lastAudio && lastAudio.blob) {
-          audioBlob = lastAudio.blob;
-          audioElement = lastAudio.audioElement || audioElement;
-          if (audioElement) {
-            this.lastKnownAudioSrc =
-              audioElement.currentSrc || audioElement.src || this.lastKnownAudioSrc;
-          }
         }
       }
 


### PR DESCRIPTION
## Summary
- guard the DOM audio discovery fallback with try/catch so store fallback can run after failures
- only refresh tracked audio element metadata when the DOM lookup succeeds
- extend the store fallback regression test to cover DOM lookup errors and preserve lastKnownAudioSrc

## Testing
- node tests/transcribe_audio_store_fallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d209bee3c4832fad07217fb460e6d0