### PR TITLE
Handle DOM audio fallback errors and extend store fallback test

### DIFF
--- a/whatsapp-ai-extension/content.js
+++ b/whatsapp-ai-extension/content.js
@@ -939,18 +939,21 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
 
       if (!audioBlob) {
         console.log('[WhatsApp AI] Buscando último áudio disponível no DOM');
+
+        let lastAudio = null;
         try {
-          const lastAudio = await this.getLastVoiceBlob();
-          if (lastAudio && lastAudio.blob) {
-            audioBlob = lastAudio.blob;
-            if (lastAudio.audioElement) {
-              audioElement = lastAudio.audioElement;
-              this.lastKnownAudioSrc =
-                audioElement.currentSrc || audioElement.src || this.lastKnownAudioSrc;
-            }
-          }
+          lastAudio = await this.getLastVoiceBlob();
         } catch (error) {
           console.warn('[WhatsApp AI] Falha ao obter último áudio do DOM', error);
+        }
+
+        if (lastAudio && lastAudio.blob) {
+          audioBlob = lastAudio.blob;
+          if (lastAudio.audioElement) {
+            audioElement = lastAudio.audioElement;
+            this.lastKnownAudioSrc =
+              audioElement.currentSrc || audioElement.src || this.lastKnownAudioSrc;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- guard `getLastVoiceBlob` calls in the content script so state is only updated when a blob is recovered
- capture readiness timeout warnings in the store fallback test and ensure the final store request succeeds after `WA_STORE_READY`

## Testing
- node tests/transcribe_audio_store_fallback.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d20d858eec832fb78de98b70f7608e