### PR TITLE
Improve store readiness handling for audio transcription

### DIFF
--- a/whatsapp-ai-extension/content.js
+++ b/whatsapp-ai-extension/content.js
@@ -166,47 +166,127 @@ function getMessageIdFromElement(element) {
   return null;
 }
 
+function waitForStoreReadySignal(extraTimeoutMs = 4000) {
+  if (window.__zapPageStoreReady) {
+    return Promise.resolve(true);
+  }
+
+  return new Promise((resolve, reject) => {
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      window.removeEventListener('message', handleReadyEvent);
+    };
+
+    const handleReadyEvent = (event) => {
+      if (event.source !== window || !event.data || event.data.type !== WA_STORE_READY) {
+        return;
+      }
+
+      window.__zapPageStoreReady = true;
+      cleanup();
+      resolve(true);
+    };
+
+    window.addEventListener('message', handleReadyEvent);
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      reject(new Error('Timeout aguardando sinal WA_STORE_READY após falha inicial'));
+    }, extraTimeoutMs);
+  });
+}
+
 async function requestStoreBlob(messageId) {
   if (!messageId) {
     throw new Error('ID da mensagem inválido');
   }
 
-  try {
-    await ensurePageStoreReady();
-  } catch (error) {
-    if (error && error.code === STORE_READY_TIMEOUT_CODE) {
-      console.warn('[WhatsApp AI] Store do WhatsApp não sinalizou readiness no tempo esperado');
-      return null;
-    }
+  const MAX_ATTEMPTS = 2;
+  let attempt = 0;
+  let waitedForReadySignal = false;
 
-    throw new Error(`Store do WhatsApp indisponível: ${error.message}`);
-  }
+  const executeStoreRequest = () =>
+    new Promise((resolve, reject) => {
+      const requestId = `wa_store_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+      const timeout = setTimeout(() => {
+        pendingStoreRequests.delete(requestId);
+        reject(new Error('Timeout aguardando resposta do Store'));
+      }, 10000);
 
-  return new Promise((resolve, reject) => {
-    const requestId = `wa_store_${Date.now()}_${Math.random().toString(16).slice(2)}`;
-    const timeout = setTimeout(() => {
-      pendingStoreRequests.delete(requestId);
-      reject(new Error('Timeout aguardando resposta do Store'));
-    }, 10000);
+      pendingStoreRequests.set(requestId, { resolve, reject, timeout });
 
-    pendingStoreRequests.set(requestId, { resolve, reject, timeout });
+      try {
+        window.postMessage(
+          {
+            type: WA_STORE_REQUEST,
+            action: 'GET_AUDIO_BLOB',
+            requestId,
+            messageId
+          },
+          '*'
+        );
+      } catch (error) {
+        clearTimeout(timeout);
+        pendingStoreRequests.delete(requestId);
+        reject(error);
+      }
+    });
+
+  while (attempt < MAX_ATTEMPTS) {
+    attempt += 1;
 
     try {
-      window.postMessage(
-        {
-          type: WA_STORE_REQUEST,
-          action: 'GET_AUDIO_BLOB',
-          requestId,
-          messageId
-        },
-        '*'
-      );
+      await ensurePageStoreReady();
     } catch (error) {
-      clearTimeout(timeout);
-      pendingStoreRequests.delete(requestId);
-      reject(error);
+      if (error && error.code === STORE_READY_TIMEOUT_CODE && !waitedForReadySignal) {
+        console.warn(
+          '[WhatsApp AI] Store do WhatsApp não sinalizou readiness no tempo esperado; aguardando sinal WA_STORE_READY para nova tentativa'
+        );
+
+        try {
+          await waitForStoreReadySignal();
+          waitedForReadySignal = true;
+          attempt -= 1;
+          continue;
+        } catch (waitError) {
+          console.warn('[WhatsApp AI] Sinal WA_STORE_READY não recebido no tempo extra aguardado', waitError);
+          return null;
+        }
+      }
+
+      throw new Error(`Store do WhatsApp indisponível: ${error.message}`);
     }
-  });
+
+    try {
+      if (waitedForReadySignal && attempt > 1) {
+        console.log('[WhatsApp AI] Repetindo solicitação de blob via Store após WA_STORE_READY');
+      }
+
+      const response = await executeStoreRequest();
+
+      if (waitedForReadySignal && attempt > 1) {
+        console.log('[WhatsApp AI] Blob recuperado com sucesso após segunda tentativa via Store');
+      }
+
+      return response;
+    } catch (error) {
+      if (attempt >= MAX_ATTEMPTS) {
+        throw error;
+      }
+
+      console.warn(
+        `[WhatsApp AI] Falha ao obter blob via Store na tentativa ${attempt}, tentando novamente`,
+        error
+      );
+    }
+  }
+
+  return null;
 }
 
 async function normalizeHelperBlob(response) {
@@ -244,7 +324,8 @@ if (typeof window !== 'undefined') {
     getMessageIdFromElement,
     requestStoreBlob,
     normalizeHelperBlob,
-    ensurePageStoreReady
+    ensurePageStoreReady,
+    waitForStoreReadySignal
   };
 }
 
@@ -920,7 +1001,7 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
             const normalized = await normalizeHelperBlob(storeResponse);
             if (normalized && normalized.blob) {
               audioBlob = normalized.blob;
-              storeMetadata = normalized.metadata || storeResponse.metadata || null;
+              storeMetadata = normalized.metadata || storeResponse?.metadata || null;
             }
           } catch (error) {
             console.warn('[WhatsApp AI] Falha ao recuperar áudio via Store', error);
@@ -961,12 +1042,47 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
         const messageId = getMessageIdFromElement(messageElement);
         if (messageId) {
           try {
+            if (!window.__zapPageStoreReady) {
+              console.log(
+                '[WhatsApp AI] Aguardando readiness do Store antes do fallback final para mensagem',
+                messageId
+              );
+
+              try {
+                await ensurePageStoreReady();
+              } catch (ensureError) {
+                if (ensureError && ensureError.code === STORE_READY_TIMEOUT_CODE) {
+                  console.warn(
+                    '[WhatsApp AI] Timeout aguardando readiness antes da tentativa final; aguardando sinal WA_STORE_READY',
+                    ensureError
+                  );
+
+                  try {
+                    await waitForStoreReadySignal();
+                  } catch (waitError) {
+                    console.warn(
+                      '[WhatsApp AI] Não foi possível confirmar readiness do Store antes da última tentativa',
+                      waitError
+                    );
+                  }
+                } else {
+                  throw ensureError;
+                }
+              }
+            }
+
             console.log('[WhatsApp AI] Tentando fallback final via Store para mensagem', messageId);
             const storeResponse = await requestStoreBlob(messageId);
             const normalized = await normalizeHelperBlob(storeResponse);
             if (normalized && normalized.blob) {
               audioBlob = normalized.blob;
-              storeMetadata = normalized.metadata || storeResponse.metadata || null;
+              storeMetadata = normalized.metadata || storeResponse?.metadata || null;
+
+              if (window.__zapPageStoreReady) {
+                console.log(
+                  '[WhatsApp AI] Blob recuperado com Store pronto na tentativa final de fallback'
+                );
+              }
             }
           } catch (error) {
             console.warn('[WhatsApp AI] Fallback via Store também falhou', error);

--- a/whatsapp-ai-extension/debug-transcricao.js
+++ b/whatsapp-ai-extension/debug-transcricao.js
@@ -26,6 +26,21 @@ async function debugTranscricaoCompleto() {
   }
   console.log('✅ API Key configurada');
 
+  // 3.1 Verificar estado do Store
+  console.log('\n🧠 VERIFICANDO ESTADO DO STORE...');
+  const storeReadyFlag = !!window.__zapPageStoreReady;
+  console.log(`WA_STORE_READY sinalizado: ${storeReadyFlag ? 'SIM' : 'NÃO'}`);
+
+  if (!storeReadyFlag && window.__zapStoreHelpers?.waitForStoreReadySignal) {
+    console.log('⏱️ Aguardando sinal WA_STORE_READY por até 4 segundos...');
+    try {
+      await window.__zapStoreHelpers.waitForStoreReadySignal(4000);
+      console.log('✅ Sinal WA_STORE_READY recebido durante o diagnóstico');
+    } catch (error) {
+      console.warn('⚠️ WA_STORE_READY não chegou dentro do tempo extra:', error.message || error);
+    }
+  }
+
   // 3. Testar API Key com OpenAI via background
   console.log('\n🔑 TESTANDO API KEY...');
   try {
@@ -137,8 +152,32 @@ async function debugTranscricaoCompleto() {
       if (messageId) {
         console.log(`🆔 ID da mensagem: ${messageId}`);
 
-        if (typeof window.whatsappAI.getWhatsAppMessageById === 'function') {
-          console.log('🧪 Solicitando GET_AUDIO_BLOB via bridge do Store...');
+        if (window.__zapStoreHelpers?.requestStoreBlob) {
+          console.log('🧪 Solicitando GET_AUDIO_BLOB com retentativa automática...');
+          try {
+            const helperResponse = await window.__zapStoreHelpers.requestStoreBlob(messageId);
+            const normalizedResult = await window.__zapStoreHelpers.normalizeHelperBlob(
+              helperResponse
+            );
+
+            if (normalizedResult?.blob instanceof Blob) {
+              console.log(
+                `✅ requestStoreBlob OK - ${normalizedResult.blob.size} bytes (${normalizedResult.blob.type ||
+                  normalizedResult.metadata?.mimeType ||
+                  helperResponse?.metadata?.mimeType ||
+                  'tipo desconhecido'})`
+              );
+            } else if (normalizedResult?.blob) {
+              console.log('⚠️ requestStoreBlob retornou dado sem formato Blob, inspecionando...');
+              console.log(normalizedResult);
+            } else {
+              console.error('❌ requestStoreBlob não retornou blob válido');
+            }
+          } catch (error) {
+            console.error('❌ Erro ao obter blob via requestStoreBlob:', error);
+          }
+        } else if (typeof window.whatsappAI.getWhatsAppMessageById === 'function') {
+          console.log('🧪 Solicitando GET_AUDIO_BLOB via bridge legado do Store...');
           try {
             const helperResponse = await window.whatsappAI.getWhatsAppMessageById(messageId);
             const normalizedBlob =
@@ -165,7 +204,7 @@ async function debugTranscricaoCompleto() {
             console.error('❌ Erro ao obter blob via bridge:', error);
           }
         } else {
-          console.warn('⚠️ Método getWhatsAppMessageById não disponível na instância whatsappAI');
+          console.warn('⚠️ Não há helper disponível para solicitar GET_AUDIO_BLOB diretamente');
         }
       } else {
         console.warn('⚠️ Não foi possível determinar o ID da mensagem de áudio');


### PR DESCRIPTION
## Summary
- wait for the WA_STORE_READY signal before retrying WhatsApp Store blob requests and log successful second attempts
- ensure audio transcription performs a final Store-backed retrieval after confirming readiness instead of failing immediately
- extend the transcription debug helper to inspect Store readiness and exercise the new retry flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2ad5c06d0832fb28d16127288f8fd