### PR TITLE
Add transcription webhook tab and routing

### DIFF
--- a/whatsapp-ai-extension/content.js
+++ b/whatsapp-ai-extension/content.js
@@ -488,7 +488,8 @@ class WhatsAppAIAssistant {
     this.button = null;
     this.settings = {
       model: 'gpt-4o',
-      responseStyle: 'Responda de forma natural e contextual, mantendo o tom da conversa'
+      responseStyle: 'Responda de forma natural e contextual, mantendo o tom da conversa',
+      transcriptionWebhookUrl: ''
     };
     this.apiKeyConfigured = false;
     this.lastKnownAudioSrc = null;
@@ -515,10 +516,11 @@ class WhatsAppAIAssistant {
 
   async loadSettings() {
     try {
-      const result = await chrome.storage.sync.get(['model', 'responseStyle']);
+      const result = await chrome.storage.sync.get(['model', 'responseStyle', 'transcriptionWebhookUrl']);
       this.settings = {
         model: result.model || 'gpt-4o',
-        responseStyle: result.responseStyle || 'Responda de forma natural e contextual, mantendo o tom da conversa'
+        responseStyle: result.responseStyle || 'Responda de forma natural e contextual, mantendo o tom da conversa',
+        transcriptionWebhookUrl: result.transcriptionWebhookUrl || ''
       };
 
       await this.ensureApiKeyConfigured();
@@ -530,7 +532,8 @@ class WhatsAppAIAssistant {
   async ensureApiKeyConfigured() {
     try {
       const response = await chrome.runtime.sendMessage({ type: 'CHECK_API_KEY' });
-      this.apiKeyConfigured = !!response?.configured;
+      const webhookConfigured = !!this.settings.transcriptionWebhookUrl || !!response?.webhookConfigured;
+      this.apiKeyConfigured = !!response?.configured || webhookConfigured;
     } catch (error) {
       console.warn('[WhatsApp AI] Não foi possível verificar estado da API Key', error);
       this.apiKeyConfigured = false;
@@ -1132,6 +1135,7 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
       let audioBlob = null;
       let audioElement = this.findPlayableAudioElementWithin(messageElement);
       let storeMetadata = null;
+      let messageId = null;
 
       if (audioElement) {
         console.log('[WhatsApp AI] Áudio encontrado diretamente na mensagem');
@@ -1141,7 +1145,7 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
       }
 
       if (!audioBlob) {
-        const messageId = getMessageIdFromElement(messageElement);
+        messageId = getMessageIdFromElement(messageElement);
         if (messageId) {
           try {
             console.log('[WhatsApp AI] Solicitando blob via Store para mensagem', messageId);
@@ -1187,7 +1191,7 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
       }
 
       if (!audioBlob) {
-        const messageId = getMessageIdFromElement(messageElement);
+        messageId = getMessageIdFromElement(messageElement);
         if (messageId) {
           try {
             console.log('[WhatsApp AI] Tentando fallback final via Store para mensagem', messageId);
@@ -1207,12 +1211,20 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
         throw new Error('Nenhum arquivo de áudio encontrado para transcrever');
       }
 
-      update({ status: 'Enviando áudio para o Whisper...' });
+      update({ status: 'Enviando áudio para transcrição...' });
 
       const mimeType = audioBlob.type || storeMetadata?.mimeType || 'audio/ogg';
-      const transcription = await this.transcribeBlobWithWhisper(audioBlob, mimeType);
+      const metadata = {
+        messageId: messageId || storeMetadata?.id || null,
+        chatId: storeMetadata?.chatId || null,
+        mimeType,
+        size: audioBlob.size || null,
+        timestamp: Date.now()
+      };
 
-      console.log('[WhatsApp AI] Transcrição concluída via Whisper');
+      const transcription = await this.transcribeBlobWithWhisper(audioBlob, mimeType, metadata);
+
+      console.log('[WhatsApp AI] Transcrição concluída');
       return transcription;
     } catch (error) {
       console.error('[WhatsApp AI] ERRO DETALHADO:', error);
@@ -1220,7 +1232,7 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
     }
   }
 
-  async transcribeBlobWithWhisper(audioBlob, mimeType = 'audio/ogg') {
+  async transcribeBlobWithWhisper(audioBlob, mimeType = 'audio/ogg', metadata = {}) {
     if (!this.isBlobLike(audioBlob)) {
       throw new Error('Fonte de áudio inválida');
     }
@@ -1229,11 +1241,20 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
     const response = await chrome.runtime.sendMessage({
       type: 'TRANSCRIBIR_AUDIO',
       arrayBuffer,
-      mime: mimeType
+      mime: mimeType,
+      metadata,
+      useWebhook: Boolean(this.settings.transcriptionWebhookUrl),
+      allowFallback: true
     });
 
     if (!response?.ok) {
       throw new Error(response?.error || 'Falha na transcrição');
+    }
+
+    if (response.usedWebhook) {
+      console.log('[WhatsApp AI] Transcrição concluída via webhook configurado');
+    } else {
+      console.log('[WhatsApp AI] Transcrição concluída via Whisper');
     }
 
     return response.text;
@@ -1281,12 +1302,43 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
     
     if (messageInput) {
       messageInput.focus();
-      messageInput.textContent = text;
-      
+
+      if (typeof messageInput.select === 'function') {
+        try {
+          messageInput.select();
+        } catch (error) {
+          console.warn('[WhatsApp AI] Falha ao selecionar campo com select()', error);
+        }
+      } else if (messageInput.isContentEditable) {
+        const selection = window.getSelection?.();
+        if (selection) {
+          const range = document.createRange();
+          range.selectNodeContents(messageInput);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+      }
+
+      let insertedWithCommand = false;
+
+      if (typeof document.execCommand === 'function') {
+        try {
+          insertedWithCommand = document.execCommand('insertText', false, text);
+          console.log('[WhatsApp AI] insertText via execCommand', insertedWithCommand ? 'sucesso' : 'falhou');
+        } catch (error) {
+          console.warn('[WhatsApp AI] execCommand insertText falhou', error);
+        }
+      }
+
+      if (!insertedWithCommand) {
+        messageInput.textContent = text;
+        console.log('[WhatsApp AI] Fallback via atribuição direta aplicado');
+      }
+
       // Dispara eventos
       messageInput.dispatchEvent(new Event('input', { bubbles: true }));
       messageInput.dispatchEvent(new Event('change', { bubbles: true }));
-      
+
       console.log('[WhatsApp AI] Texto inserido');
     } else {
       console.log('[WhatsApp AI] Campo de input não encontrado');

--- a/whatsapp-ai-extension/manifest.json
+++ b/whatsapp-ai-extension/manifest.json
@@ -9,7 +9,9 @@
   ],
   "host_permissions": [
     "https://web.whatsapp.com/*",
-    "https://api.openai.com/*"
+    "https://api.openai.com/*",
+    "https://*/*",
+    "http://*/*"
   ],
   "content_scripts": [
     {

--- a/whatsapp-ai-extension/popup.css
+++ b/whatsapp-ai-extension/popup.css
@@ -51,6 +51,47 @@ body {
   padding: 24px;
 }
 
+.tabs {
+  display: flex;
+  gap: 8px;
+  background: #F3F4F6;
+  padding: 6px;
+  border-radius: 12px;
+  margin-bottom: 24px;
+}
+
+.tab-button {
+  flex: 1;
+  border: none;
+  background: transparent;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #6B7280;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab-button:hover {
+  background: rgba(37, 211, 102, 0.08);
+  color: #128C7E;
+}
+
+.tab-button.active {
+  background: white;
+  color: #128C7E;
+  box-shadow: 0 4px 12px rgba(18, 140, 126, 0.15);
+}
+
+.tab-content {
+  display: none;
+}
+
+.tab-content.active {
+  display: block;
+}
+
 .section {
   margin-bottom: 24px;
 }
@@ -74,6 +115,7 @@ label {
 }
 
 input[type="text"],
+input[type="url"],
 input[type="password"],
 select,
 textarea {
@@ -238,6 +280,34 @@ button.loading svg {
   background: #EFF6FF;
   color: #1E40AF;
   border: 1px solid #BFDBFE;
+}
+
+.status.warning {
+  background: #FFFBEB;
+  color: #92400E;
+  border: 1px solid #FDE68A;
+}
+
+.webhook-info {
+  background: #F9FAFB;
+  border: 1px solid #E5E7EB;
+  border-radius: 12px;
+  padding: 16px;
+  font-size: 13px;
+  color: #374151;
+  line-height: 1.5;
+}
+
+.webhook-info p + p {
+  margin-top: 8px;
+}
+
+.webhook-info code {
+  background: rgba(55, 65, 81, 0.08);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 12px;
 }
 
 .footer {

--- a/whatsapp-ai-extension/popup.html
+++ b/whatsapp-ai-extension/popup.html
@@ -20,38 +20,59 @@
     </div>
 
     <div class="content">
-      <div class="section">
-        <label for="apiKey">API Key OpenAI:</label>
-        <div class="input-group">
-          <input type="password" id="apiKey" placeholder="sk-..." />
-          <button type="button" id="toggleApiKey" class="toggle-btn">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" stroke="currentColor" stroke-width="2"/>
-              <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2"/>
-            </svg>
-          </button>
+      <div class="tabs">
+        <button class="tab-button active" data-tab-button data-tab="general">Geral</button>
+        <button class="tab-button" data-tab-button data-tab="transcription">Transcrição</button>
+      </div>
+
+      <div class="tab-content active" data-tab="general">
+        <div class="section">
+          <label for="apiKey">API Key OpenAI:</label>
+          <div class="input-group">
+            <input type="password" id="apiKey" placeholder="sk-..." />
+            <button type="button" id="toggleApiKey" class="toggle-btn">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" stroke="currentColor" stroke-width="2"/>
+                <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="section">
+          <label for="model">Modelo OpenAI:</label>
+          <select id="model">
+            <option value="gpt-4o">GPT-4o (Mais Avançado)</option>
+            <option value="gpt-4o-mini">GPT-4o Mini (Mais Rápido)</option>
+            <option value="gpt-4-turbo">GPT-4 Turbo</option>
+            <option value="gpt-3.5-turbo">GPT-3.5 Turbo (Econômico)</option>
+          </select>
+        </div>
+
+        <div class="section">
+          <label for="responseStyle">Estilo das Respostas:</label>
+          <textarea
+            id="responseStyle"
+            rows="4"
+            placeholder="Ex: Responda sempre de forma amigável e casual, usando emojis quando apropriado..."
+          ></textarea>
+          <div class="help-text">
+            Descreva como você quer que a IA responda (tom, estilo, personalidade)
+          </div>
         </div>
       </div>
 
-      <div class="section">
-        <label for="model">Modelo OpenAI:</label>
-        <select id="model">
-          <option value="gpt-4o">GPT-4o (Mais Avançado)</option>
-          <option value="gpt-4o-mini">GPT-4o Mini (Mais Rápido)</option>
-          <option value="gpt-4-turbo">GPT-4 Turbo</option>
-          <option value="gpt-3.5-turbo">GPT-3.5 Turbo (Econômico)</option>
-        </select>
-      </div>
-
-      <div class="section">
-        <label for="responseStyle">Estilo das Respostas:</label>
-        <textarea 
-          id="responseStyle" 
-          rows="4" 
-          placeholder="Ex: Responda sempre de forma amigável e casual, usando emojis quando apropriado..."
-        ></textarea>
-        <div class="help-text">
-          Descreva como você quer que a IA responda (tom, estilo, personalidade)
+      <div class="tab-content" data-tab="transcription">
+        <div class="section">
+          <label for="transcriptionWebhookUrl">Webhook de Transcrição (n8n):</label>
+          <input type="url" id="transcriptionWebhookUrl" placeholder="https://seu-servidor.n8n.cloud/webhook" />
+          <div class="help-text">
+            Informe a URL do fluxo que receberá o áudio. Se deixar vazio, a transcrição usará o Whisper padrão da OpenAI.
+          </div>
+        </div>
+        <div class="webhook-info">
+          <p>O webhook recebe o arquivo (campo <strong>file</strong>) e um JSON de metadados (campo <strong>metadata</strong>).</p>
+          <p>Retorne <code>{ "text": "sua transcrição" }</code> ou texto puro com a transcrição para continuar o fluxo.</p>
         </div>
       </div>
 

--- a/whatsapp-ai-extension/popup.js
+++ b/whatsapp-ai-extension/popup.js
@@ -5,17 +5,22 @@ class PopupManager {
       apiKey: document.getElementById('apiKey'),
       model: document.getElementById('model'),
       responseStyle: document.getElementById('responseStyle'),
+      transcriptionWebhookUrl: document.getElementById('transcriptionWebhookUrl'),
       saveButton: document.getElementById('saveButton'),
       testButton: document.getElementById('testButton'),
       toggleApiKey: document.getElementById('toggleApiKey'),
-      status: document.getElementById('status')
+      status: document.getElementById('status'),
+      tabButtons: document.querySelectorAll('[data-tab-button]'),
+      tabContents: document.querySelectorAll('.tab-content')
     };
-    
+
+    this.activeTab = 'general';
     this.init();
   }
 
   async init() {
     await this.loadSettings();
+    this.setupTabs();
     this.attachEventListeners();
     this.setDefaultValues();
   }
@@ -23,7 +28,7 @@ class PopupManager {
   async loadSettings() {
     try {
       const [syncSettings, localSettings] = await Promise.all([
-        chrome.storage.sync.get(['model', 'responseStyle']),
+        chrome.storage.sync.get(['model', 'responseStyle', 'transcriptionWebhookUrl']),
         chrome.storage.local.get('OPENAI_KEY')
       ]);
 
@@ -35,6 +40,9 @@ class PopupManager {
       }
       if (syncSettings.responseStyle) {
         this.elements.responseStyle.value = syncSettings.responseStyle;
+      }
+      if (this.elements.transcriptionWebhookUrl) {
+        this.elements.transcriptionWebhookUrl.value = syncSettings.transcriptionWebhookUrl || '';
       }
 
     } catch (error) {
@@ -51,12 +59,17 @@ class PopupManager {
   attachEventListeners() {
     this.elements.saveButton.addEventListener('click', () => this.saveSettings());
     this.elements.testButton.addEventListener('click', () => this.testAPI());
-    this.elements.toggleApiKey.addEventListener('click', () => this.toggleApiKeyVisibility());
-    
+    if (this.elements.toggleApiKey) {
+      this.elements.toggleApiKey.addEventListener('click', () => this.toggleApiKeyVisibility());
+    }
+
     // Auto-save quando os campos mudam
     this.elements.apiKey.addEventListener('input', () => this.debounceAutoSave());
     this.elements.model.addEventListener('change', () => this.autoSave());
     this.elements.responseStyle.addEventListener('input', () => this.debounceAutoSave());
+    if (this.elements.transcriptionWebhookUrl) {
+      this.elements.transcriptionWebhookUrl.addEventListener('input', () => this.debounceAutoSave());
+    }
   }
 
   debounceAutoSave() {
@@ -67,13 +80,16 @@ class PopupManager {
   async autoSave() {
     try {
       const apiKey = this.elements.apiKey.value.trim();
+      const webhookUrl = this.elements.transcriptionWebhookUrl?.value.trim() || '';
       await Promise.all([
         chrome.storage.local.set({ OPENAI_KEY: apiKey }),
         chrome.storage.sync.set({
           model: this.elements.model.value,
-          responseStyle: this.elements.responseStyle.value.trim()
+          responseStyle: this.elements.responseStyle.value.trim(),
+          transcriptionWebhookUrl: webhookUrl
         })
       ]);
+      this.notifyContentScripts();
     } catch (error) {
       console.error('Erro no auto-save:', error);
     }
@@ -83,9 +99,10 @@ class PopupManager {
     const apiKey = this.elements.apiKey.value.trim();
     const model = this.elements.model.value;
     const responseStyle = this.elements.responseStyle.value.trim();
+    const webhookUrl = this.elements.transcriptionWebhookUrl?.value.trim() || '';
 
-    if (!apiKey) {
-      this.showStatus('Por favor, insira sua API Key da OpenAI', 'error');
+    if (!apiKey && !webhookUrl) {
+      this.showStatus('Informe a API Key da OpenAI ou um webhook de transcrição', 'error');
       return;
     }
 
@@ -101,7 +118,8 @@ class PopupManager {
         chrome.storage.local.set({ OPENAI_KEY: apiKey }),
         chrome.storage.sync.set({
           model,
-          responseStyle
+          responseStyle,
+          transcriptionWebhookUrl: webhookUrl
         })
       ]);
 
@@ -120,9 +138,14 @@ class PopupManager {
   async testAPI() {
     const apiKey = this.elements.apiKey.value.trim();
     const model = this.elements.model.value;
+    const webhookUrl = this.elements.transcriptionWebhookUrl?.value.trim();
 
     if (!apiKey) {
-      this.showStatus('Insira sua API Key primeiro', 'error');
+      if (webhookUrl) {
+        this.showStatus('Configure uma API Key para testar a OpenAI. O webhook será usado apenas na transcrição.', 'warning');
+      } else {
+        this.showStatus('Insira sua API Key primeiro', 'error');
+      }
       return;
     }
 
@@ -196,13 +219,47 @@ class PopupManager {
 
   showStatus(message, type = 'info') {
     this.elements.status.textContent = message;
-    this.elements.status.className = `status ${type}`;
-    
-    if (type === 'success' || type === 'error') {
+      this.elements.status.className = `status ${type}`;
+
+    if (type === 'success' || type === 'error' || type === 'warning') {
       setTimeout(() => {
         this.elements.status.textContent = '';
         this.elements.status.className = 'status';
       }, 3000);
+    }
+  }
+
+  setupTabs() {
+    const buttons = this.elements.tabButtons;
+    if (!buttons || buttons.length === 0) {
+      return;
+    }
+
+    buttons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const targetTab = button.dataset.tab;
+        this.switchTab(targetTab);
+      });
+    });
+  }
+
+  switchTab(tab) {
+    if (!tab || tab === this.activeTab) {
+      return;
+    }
+
+    this.activeTab = tab;
+
+    if (this.elements.tabButtons) {
+      this.elements.tabButtons.forEach((button) => {
+        button.classList.toggle('active', button.dataset.tab === tab);
+      });
+    }
+
+    if (this.elements.tabContents) {
+      this.elements.tabContents.forEach((content) => {
+        content.classList.toggle('active', content.dataset.tab === tab);
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a dedicated Transcrição tab in the popup to configure the transcription webhook
- persist the webhook URL, relax validation to allow webhook-only setups, and surface a warning when testing without API key
- route audio blobs through the configured webhook with metadata before falling back to Whisper, including host permissions updates

## Testing
- not run (manual extension testing required)


------
https://chatgpt.com/codex/tasks/task_e_68d2d615b8e8832fa2c47b75bec8092b