### PR TITLE
Add OpenAI chat modal to homepage

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,3 +23,4 @@ numpy>=1.26.0
 python-multipart>=0.0.9
 jq>=1.6.0
 typer>=0.9.0
+openai>=1.53.0

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI, APIRouter
+import asyncio
+from fastapi import FastAPI, APIRouter, HTTPException
 from dotenv import load_dotenv
 from starlette.middleware.cors import CORSMiddleware
 from motor.motor_asyncio import AsyncIOMotorClient
@@ -6,9 +7,10 @@ import os
 import logging
 from pathlib import Path
 from pydantic import BaseModel, Field
-from typing import List
+from typing import List, Optional
 import uuid
 from datetime import datetime
+from openai import OpenAI
 
 
 ROOT_DIR = Path(__file__).parent
@@ -18,6 +20,13 @@ load_dotenv(ROOT_DIR / '.env')
 mongo_url = os.environ['MONGO_URL']
 client = AsyncIOMotorClient(mongo_url)
 db = client[os.environ['DB_NAME']]
+
+openai_api_key = os.environ.get('OPENAI_API_KEY')
+openai_model = os.environ.get('OPENAI_MODEL', 'gpt-4o-mini')
+openai_client: Optional[OpenAI] = None
+
+if openai_api_key:
+    openai_client = OpenAI(api_key=openai_api_key)
 
 # Create the main app without a prefix
 app = FastAPI()
@@ -35,6 +44,16 @@ class StatusCheck(BaseModel):
 class StatusCheckCreate(BaseModel):
     client_name: str
 
+
+class ChatRequest(BaseModel):
+    question: str
+    context: Optional[str] = None
+
+
+class ChatResponse(BaseModel):
+    answer: str
+
+
 # Add your routes to the router instead of directly to app
 @api_router.get("/")
 async def root():
@@ -51,6 +70,49 @@ async def create_status_check(input: StatusCheckCreate):
 async def get_status_checks():
     status_checks = await db.status_checks.find().to_list(1000)
     return [StatusCheck(**status_check) for status_check in status_checks]
+
+
+@api_router.post("/ask", response_model=ChatResponse)
+async def ask_openai(request: ChatRequest):
+    if not request.question.strip():
+        raise HTTPException(status_code=400, detail="A pergunta não pode estar vazia.")
+
+    if openai_client is None:
+        raise HTTPException(
+            status_code=503,
+            detail="O serviço de linguagem não está configurado. Defina OPENAI_API_KEY.",
+        )
+
+    prompt = request.question.strip()
+    if request.context:
+        prompt = f"{request.context.strip()}\n\nPergunta: {prompt}"
+
+    loop = asyncio.get_running_loop()
+
+    try:
+        response = await loop.run_in_executor(
+            None,
+            lambda: openai_client.responses.create(
+                model=openai_model,
+                input=prompt,
+            ),
+        )
+    except Exception as exc:  # pragma: no cover - network failure path
+        logger.exception("Erro ao consultar o OpenAI: %s", exc)
+        raise HTTPException(
+            status_code=502,
+            detail="Não foi possível obter uma resposta do modelo de linguagem.",
+        ) from exc
+
+    answer_text = (response.output_text or "").strip()
+
+    if not answer_text:
+        raise HTTPException(
+            status_code=502,
+            detail="O modelo de linguagem não retornou conteúdo.",
+        )
+
+    return ChatResponse(answer=answer_text)
 
 # Include the router in the main app
 app.include_router(api_router)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -18,10 +18,163 @@
     justify-content: center;
     font-size: calc(10px + 2vmin);
     color: white;
+    position: relative;
+    padding: 2rem 1.5rem 1.5rem;
+    box-sizing: border-box;
 }
 
 .App-link {
     color: #61dafb;
+}
+
+.ask-ai-button {
+    position: absolute;
+    top: 1.5rem;
+    right: 1.5rem;
+    padding: 0.75rem 1.5rem;
+    border-radius: 9999px;
+    border: none;
+    background: linear-gradient(135deg, #6a5acd, #00bcd4);
+    color: #ffffff;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 10px 30px rgba(0, 188, 212, 0.3);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ask-ai-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 34px rgba(106, 90, 205, 0.35);
+}
+
+.ask-ai-button:focus {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 2px;
+}
+
+.ai-modal-backdrop {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.65);
+    backdrop-filter: blur(2px);
+    padding: 1rem;
+    box-sizing: border-box;
+    z-index: 999;
+}
+
+.ai-modal {
+    width: min(560px, 100%);
+    background: #151517;
+    border-radius: 20px;
+    padding: 2rem;
+    box-shadow: 0 40px 80px rgba(0, 0, 0, 0.45);
+    color: #f1f5f9;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.ai-modal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.ai-modal-header h2 {
+    font-size: 1.5rem;
+    margin: 0;
+}
+
+.ai-close-button {
+    background: none;
+    border: none;
+    color: #94a3b8;
+    font-size: 2rem;
+    cursor: pointer;
+    line-height: 1;
+    transition: color 0.2s ease;
+}
+
+.ai-close-button:hover {
+    color: #e2e8f0;
+}
+
+.ai-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.ai-label {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #cbd5f5;
+}
+
+.ai-textarea {
+    resize: vertical;
+    min-height: 120px;
+    border-radius: 14px;
+    border: 1px solid rgba(148, 163, 184, 0.3);
+    padding: 1rem;
+    font-size: 1rem;
+    color: #e2e8f0;
+    background: rgba(15, 23, 42, 0.6);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.ai-textarea:focus {
+    outline: none;
+    border-color: rgba(59, 130, 246, 0.6);
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.ai-error {
+    margin: 0;
+    color: #f87171;
+    font-size: 0.9rem;
+}
+
+.ai-submit {
+    align-self: flex-end;
+    padding: 0.7rem 1.5rem;
+    border-radius: 9999px;
+    border: none;
+    background: linear-gradient(135deg, #38bdf8, #6366f1);
+    color: #f8fafc;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.ai-submit:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.ai-submit:not(:disabled):hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 30px rgba(99, 102, 241, 0.45);
+}
+
+.ai-response {
+    border-radius: 14px;
+    background: rgba(15, 23, 42, 0.7);
+    padding: 1.25rem;
+    line-height: 1.6;
+    color: #e2e8f0;
+}
+
+.ai-response h3 {
+    margin: 0 0 0.75rem 0;
+    font-size: 1.1rem;
+    color: #bfdbfe;
 }
 
 @keyframes App-logo-spin {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import "./App.css";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import axios from "axios";
@@ -7,12 +7,71 @@ const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 const API = `${BACKEND_URL}/api`;
 
 const Home = () => {
+  const [isChatOpen, setIsChatOpen] = useState(false);
+  const [question, setQuestion] = useState("");
+  const [answer, setAnswer] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+
   const helloWorldApi = async () => {
     try {
       const response = await axios.get(`${API}/`);
       console.log(response.data.message);
     } catch (e) {
       console.error(e, `errored out requesting / api`);
+    }
+  };
+
+  const closeChat = () => {
+    setIsChatOpen(false);
+    setQuestion("");
+    setAnswer("");
+    setError("");
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    if (!isChatOpen) {
+      return undefined;
+    }
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        closeChat();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isChatOpen]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    const trimmedQuestion = question.trim();
+
+    if (!trimmedQuestion) {
+      setError("Digite uma pergunta antes de enviar.");
+      return;
+    }
+
+    setIsLoading(true);
+    setError("");
+    setAnswer("");
+
+    try {
+      const response = await axios.post(`${API}/ask`, {
+        question: trimmedQuestion,
+      });
+
+      setAnswer(response.data.answer);
+    } catch (askError) {
+      console.error("Erro ao consultar a IA", askError);
+      setError("Não foi possível obter uma resposta agora. Tente novamente em instantes.");
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -23,6 +82,9 @@ const Home = () => {
   return (
     <div>
       <header className="App-header">
+        <button className="ask-ai-button" type="button" onClick={() => setIsChatOpen(true)}>
+          Perguntar à IA
+        </button>
         <a
           className="App-link"
           href="https://emergent.sh"
@@ -32,6 +94,47 @@ const Home = () => {
           <img src="https://avatars.githubusercontent.com/in/1201222?s=120&u=2686cf91179bbafbc7a71bfbc43004cf9ae1acea&v=4" />
         </a>
         <p className="mt-5">Building something incredible ~!</p>
+        {isChatOpen ? (
+          <div
+            className="ai-modal-backdrop"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="ai-modal-title"
+            onClick={closeChat}
+          >
+            <div className="ai-modal" onClick={(event) => event.stopPropagation()}>
+              <div className="ai-modal-header">
+                <h2 id="ai-modal-title">Converse com a inteligência artificial</h2>
+                <button className="ai-close-button" type="button" onClick={closeChat} aria-label="Fechar">
+                  ×
+                </button>
+              </div>
+              <form className="ai-form" onSubmit={handleSubmit}>
+                <label className="ai-label" htmlFor="ai-question">
+                  Faça sua pergunta personalizada
+                </label>
+                <textarea
+                  id="ai-question"
+                  className="ai-textarea"
+                  value={question}
+                  onChange={(event) => setQuestion(event.target.value)}
+                  rows={4}
+                  placeholder="Como posso ajudar hoje?"
+                />
+                {error && <p className="ai-error">{error}</p>}
+                <button className="ai-submit" type="submit" disabled={isLoading}>
+                  {isLoading ? "Consultando..." : "Enviar"}
+                </button>
+              </form>
+              {answer && (
+                <div className="ai-response">
+                  <h3>Resposta</h3>
+                  <p>{answer}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        ) : null}
       </header>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint that proxies custom questions to the OpenAI Responses API with input validation and error handling
- extend the homepage with an “Perguntar à IA” button that opens a modal, submits prompts to the backend and shows answers or errors
- style the new modal experience and include the OpenAI SDK dependency

## Testing
- python -m compileall backend
- yarn test --watchAll=false *(fails: unable to download yarn package manager because of network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ebdac774832faba715fa85640c6e