### PR TITLE
Add floating ask AI button with label

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -27,30 +27,48 @@
     color: #61dafb;
 }
 
-.ask-ai-button {
-    position: absolute;
-    top: 1.5rem;
+.ask-ai-fab {
+    position: fixed;
+    bottom: 1.5rem;
     right: 1.5rem;
-    padding: 0.75rem 1.5rem;
-    border-radius: 9999px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    z-index: 998;
+}
+
+.ask-ai-label-text {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #f8fafc;
+    text-shadow: 0 2px 4px rgba(15, 15, 16, 0.6);
+}
+
+.ask-ai-fab-button {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
     border: none;
     background: linear-gradient(135deg, #6a5acd, #00bcd4);
     color: #ffffff;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 2rem;
+    font-weight: 700;
     cursor: pointer;
-    box-shadow: 0 10px 30px rgba(0, 188, 212, 0.3);
+    box-shadow: 0 12px 32px rgba(0, 188, 212, 0.35);
+    display: grid;
+    place-items: center;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.ask-ai-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 14px 34px rgba(106, 90, 205, 0.35);
+.ask-ai-fab-button:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 16px 40px rgba(106, 90, 205, 0.4);
 }
 
-.ask-ai-button:focus {
+.ask-ai-fab-button:focus {
     outline: 2px solid rgba(255, 255, 255, 0.6);
-    outline-offset: 2px;
+    outline-offset: 3px;
 }
 
 .ai-modal-backdrop {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -82,9 +82,17 @@ const Home = () => {
   return (
     <div>
       <header className="App-header">
-        <button className="ask-ai-button" type="button" onClick={() => setIsChatOpen(true)}>
-          Perguntar à IA
-        </button>
+        <div className="ask-ai-fab">
+          <span className="ask-ai-label-text">Pergunte a I.A</span>
+          <button
+            className="ask-ai-fab-button"
+            type="button"
+            onClick={() => setIsChatOpen(true)}
+            aria-label="Abrir chat com a inteligência artificial"
+          >
+            IA
+          </button>
+        </div>
         <a
           className="App-link"
           href="https://emergent.sh"


### PR DESCRIPTION
## Summary
- replace the top-right ask AI trigger with a floating action button anchored to the bottom-right corner
- show the "Pergunte a I.A" helper label above the new circular button
- keep the modal trigger logic intact while updating styles for the new layout

## Testing
- `CI=true yarn --cwd frontend test --watchAll=false` *(fails: Missing yarn classic lockfile; repository does not ship dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d40a504a48832fa28e9e12e5fa5ead