### PR TITLE
Adjust floating WhatsApp AI button layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -27,30 +27,48 @@
     color: #61dafb;
 }
 
-.ask-ai-button {
-    position: absolute;
-    top: 1.5rem;
+.ask-ai-fab {
+    position: fixed;
+    bottom: 1.5rem;
     right: 1.5rem;
-    padding: 0.75rem 1.5rem;
-    border-radius: 9999px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    z-index: 998;
+}
+
+.ask-ai-label-text {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #f8fafc;
+    text-shadow: 0 2px 4px rgba(15, 15, 16, 0.6);
+}
+
+.ask-ai-fab-button {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
     border: none;
     background: linear-gradient(135deg, #6a5acd, #00bcd4);
     color: #ffffff;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 2rem;
+    font-weight: 700;
     cursor: pointer;
-    box-shadow: 0 10px 30px rgba(0, 188, 212, 0.3);
+    box-shadow: 0 12px 32px rgba(0, 188, 212, 0.35);
+    display: grid;
+    place-items: center;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.ask-ai-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 14px 34px rgba(106, 90, 205, 0.35);
+.ask-ai-fab-button:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 16px 40px rgba(106, 90, 205, 0.4);
 }
 
-.ask-ai-button:focus {
+.ask-ai-fab-button:focus {
     outline: 2px solid rgba(255, 255, 255, 0.6);
-    outline-offset: 2px;
+    outline-offset: 3px;
 }
 
 .ai-modal-backdrop {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -82,9 +82,17 @@ const Home = () => {
   return (
     <div>
       <header className="App-header">
-        <button className="ask-ai-button" type="button" onClick={() => setIsChatOpen(true)}>
-          Perguntar à IA
-        </button>
+        <div className="ask-ai-fab">
+          <span className="ask-ai-label-text">Pergunte a I.A</span>
+          <button
+            className="ask-ai-fab-button"
+            type="button"
+            onClick={() => setIsChatOpen(true)}
+            aria-label="Abrir chat com a inteligência artificial"
+          >
+            IA
+          </button>
+        </div>
         <a
           className="App-link"
           href="https://emergent.sh"

--- a/whatsapp-ai-extension/content.js
+++ b/whatsapp-ai-extension/content.js
@@ -155,23 +155,30 @@ class WhatsAppAIAssistant {
     console.log('[WhatsApp AI] Criando botão flutuante...');
 
     this.button = document.createElement('div');
-    this.button.className = 'whatsapp-ai-button hidden';
+    this.button.className = 'whatsapp-ai-floating-wrapper hidden';
     this.button.innerHTML = `
-      <div class="ai-button-content">
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M12 2L2 7L12 12L22 7L12 2Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-          <path d="M2 17L12 22L22 17" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-          <path d="M2 12L12 17L22 12" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
-        </svg>
-        <span>IA</span>
-      </div>
-      <div class="ai-button-tooltip">Gerar Resposta com IA</div>
+      <span class="whatsapp-ai-floating-label">Pergunte a I.A</span>
+      <button type="button" class="whatsapp-ai-button" aria-label="Gerar resposta com inteligência artificial">
+        <div class="ai-button-content">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 2L2 7L12 12L22 7L12 2Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+            <path d="M2 17L12 22L22 17" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+            <path d="M2 12L12 17L22 12" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+          </svg>
+          <span>IA</span>
+        </div>
+        <div class="ai-button-tooltip">Gerar Resposta com IA</div>
+      </button>
     `;
 
-    this.button.addEventListener('click', () => {
+    const triggerButton = this.button.querySelector('.whatsapp-ai-button');
+
+    triggerButton?.addEventListener('click', () => {
       console.log('[WhatsApp AI] Botão clicado!');
       this.generateResponse();
     });
+
+    this.buttonTrigger = triggerButton;
 
     document.body.appendChild(this.button);
     console.log('[WhatsApp AI] Botão criado e adicionado ao DOM');
@@ -312,8 +319,8 @@ class WhatsAppAIAssistant {
       return;
     }
 
-    if (this.button) {
-      this.button.classList.add('loading');
+    if (this.buttonTrigger) {
+      this.buttonTrigger.classList.add('loading');
     }
     this.showNotification('✍️ Analisando conversa recente...', 'info');
 
@@ -363,8 +370,8 @@ IMPORTANTE: Responda APENAS com a mensagem que deveria ser enviada. Não inclua 
 
       this.showNotification(errorMessage, 'error');
     } finally {
-      if (this.button) {
-        this.button.classList.remove('loading');
+      if (this.buttonTrigger) {
+        this.buttonTrigger.classList.remove('loading');
       }
     }
   }

--- a/whatsapp-ai-extension/styles.css
+++ b/whatsapp-ai-extension/styles.css
@@ -1,22 +1,58 @@
 /* Estilos para o botão flutuante no WhatsApp Web */
-.whatsapp-ai-button {
+.whatsapp-ai-floating-wrapper {
   position: fixed;
   bottom: 120px;
   right: 20px;
-  width: 50px;
-  height: 50px;
-  background: linear-gradient(135deg, #25D366, #128C7E);
-  border-radius: 50%;
-  cursor: pointer;
-  box-shadow: 0 6px 20px rgba(37, 211, 102, 0.3);
-  z-index: 999999;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  gap: 10px;
+  z-index: 999999;
   transform: scale(0);
   opacity: 0;
   user-select: none;
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.3s ease;
+}
+
+.whatsapp-ai-floating-wrapper.visible {
+  transform: scale(1);
+  opacity: 1;
+  animation: bounceIn 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+  pointer-events: auto;
+}
+
+.whatsapp-ai-floating-wrapper.hidden {
+  transform: scale(0);
+  opacity: 0;
+  pointer-events: none;
+  transition: all 0.3s ease-in-out;
+}
+
+.whatsapp-ai-floating-label {
+  font-size: 12px;
+  font-weight: 600;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  color: #f8fafc;
+  background: rgba(15, 23, 42, 0.85);
+  padding: 6px 14px;
+  border-radius: 999px;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.35);
+  letter-spacing: 0.3px;
+}
+
+.whatsapp-ai-button {
+  width: 62px;
+  height: 62px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  background: linear-gradient(135deg, #25D366, #128C7E);
+  box-shadow: 0 6px 20px rgba(37, 211, 102, 0.3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  position: relative;
 }
 
 .whatsapp-ai-header-button-wrapper {
@@ -74,21 +110,14 @@
 }
 
 .whatsapp-ai-button:hover {
-  transform: scale(1.1);
+  transform: translateY(-4px);
   box-shadow: 0 12px 35px rgba(37, 211, 102, 0.4);
   background: linear-gradient(135deg, #128C7E, #25D366);
 }
 
-.whatsapp-ai-button.visible {
-  transform: scale(1);
-  opacity: 1;
-  animation: bounceIn 0.6s cubic-bezier(0.68, -0.55, 0.265, 1.55);
-}
-
-.whatsapp-ai-button.hidden {
-  transform: scale(0);
-  opacity: 0;
-  transition: all 0.3s ease-in-out;
+.whatsapp-ai-button:focus-visible {
+  outline: 3px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 3px;
 }
 
 .whatsapp-ai-button.loading {
@@ -124,7 +153,7 @@
 
 .ai-button-tooltip {
   position: absolute;
-  right: 60px;
+  right: 70px;
   top: 50%;
   transform: translateY(-50%);
   background: rgba(0, 0, 0, 0.85);


### PR DESCRIPTION
## Summary
- move the "Pergunte a I.A" helper label and floating action button implementation to the WhatsApp extension
- render the helper label above the circular button while keeping the tooltip anchored to the trigger
- update button animations and loading state handling to work with the new markup structure

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d40a504a48832fa28e9e12e5fa5ead